### PR TITLE
Tests for setting distances for each grid point

### DIFF
--- a/src/diffpy/labpdfproc/functions.py
+++ b/src/diffpy/labpdfproc/functions.py
@@ -59,7 +59,6 @@ class Gridded_circle:
             self.secondary_distances.append(secondary)
 
     def set_muls_at_angle(self, angle):
-        # newly added docstring
         """
         compute muls = exp(-mu*distance) for a given angle
 
@@ -129,7 +128,7 @@ class Gridded_circle:
             xexit_root1, xexit_root2 = np.roots((1 + a**2, 2 * a * b, b**2 - self.radius**2))
             yexit_root1 = a * xexit_root1 + b
             yexit_root2 = a * xexit_root2 + b
-            if yexit_root2 >= ygrid:  # We pick the point above
+            if yexit_root2 >= yexit_root1:  # We pick the point above
                 exit_point = (xexit_root2, yexit_root2)
             else:
                 exit_point = (xexit_root1, yexit_root1)

--- a/src/diffpy/labpdfproc/tests/test_functions.py
+++ b/src/diffpy/labpdfproc/tests/test_functions.py
@@ -2,21 +2,16 @@ import pytest
 
 from diffpy.labpdfproc.functions import Gridded_circle
 
-# Define test parameters
-params1 = [
-    ([0.5, 3, 1], {(0.0, -0.5), (0.0, 0.0), (0.5, 0.0), (-0.5, 0.0), (0.0, 0.5)}),
-    ([1, 4, 1], {(-0.333333, -0.333333), (0.333333, -0.333333), (-0.333333, 0.333333), (0.333333, 0.333333)}),
+params2 = [
+    ([1, 3, 1, 45], [0, 1.4142135, 1.4142135, 2, 2]),
+    ([1, 3, 1, 90], [0, 0, 2, 2, 2]),
+    ([1, 3, 1, 140], [0, 2, 0, 3.5320888862379562, 1.2855752193730785]),
 ]
 
 
-# Define the test function
-@pytest.mark.parametrize("inputs, expected", params1)
-def test_get_grid_points(inputs, expected):
-    expected_grid = expected
+@pytest.mark.parametrize("inputs, expected", params2)
+def test_set_distances_at_angle(inputs, expected):
+    expected_distances = expected
     actual_gs = Gridded_circle(radius=inputs[0], n_points_on_diameter=inputs[1], mu=inputs[2])
-    assert actual_gs.grid == expected_grid
-
-
-#    assert actual_gs.grid == pytest.approx(expected_grid)
-# for actual_point, expected_point in zip(actual_grid_sorted, expected_grid_sorted):
-#     assert actual_point == pytest.approx(expected_point, rel=1e-4, abs=1e-6)
+    actual_gs.set_distances_at_angle(inputs[3])
+    assert actual_gs.distances == pytest.approx(expected_distances, rel=1e-4, abs=1e-6)

--- a/src/diffpy/labpdfproc/tests/test_functions.py
+++ b/src/diffpy/labpdfproc/tests/test_functions.py
@@ -16,3 +16,18 @@ def test_get_grid_points(inputs, expected):
     expected_grid_sorted = sorted(expected_grid)
     for actual_point, expected_point in zip(actual_grid_sorted, expected_grid_sorted):
         assert actual_point == pytest.approx(expected_point, rel=1e-4, abs=1e-6)
+
+
+params2 = [
+    ([1, 3, 1, 45], [0, 1.4142135, 1.4142135, 2, 2]),
+    ([1, 3, 1, 90], [0, 0, 2, 2, 2]),
+    ([1, 3, 1, 140], [0, 2, 0, 3.532, 1.2855]),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params2)
+def test_set_distances_at_angle(inputs, expected):
+    expected_distances = expected
+    actual_gs = Gridded_circle(radius=inputs[0], n_points_on_diameter=inputs[1], mu=inputs[2])
+    actual_gs.set_distances_at_angle(inputs[3])
+    assert actual_gs.distances == pytest.approx(expected_distances, rel=1e-4, abs=1e-6)

--- a/src/diffpy/labpdfproc/tests/test_functions.py
+++ b/src/diffpy/labpdfproc/tests/test_functions.py
@@ -21,7 +21,10 @@ def test_get_grid_points(inputs, expected):
 params2 = [
     ([1, 3, 1, 45], [0, 1.4142135, 1.4142135, 2, 2]),
     ([1, 3, 1, 90], [0, 0, 2, 2, 2]),
-    ([1, 3, 1, 140], [0, 2, 0, 3.532, 1.2855]),
+    ([1, 3, 1, 120], [0, 0, 2, 3, 1.73205]),
+    ([1, 4, 1, 30], [2.057347, 2.044451, 1.621801, 1.813330]),
+    ([1, 4, 1, 90], [1.885618, 1.885618, 2.552285, 1.218951]),
+    ([1, 4, 1, 140], [1.139021, 2.200102, 2.744909, 1.451264]),
 ]
 
 
@@ -30,4 +33,6 @@ def test_set_distances_at_angle(inputs, expected):
     expected_distances = expected
     actual_gs = Gridded_circle(radius=inputs[0], n_points_on_diameter=inputs[1], mu=inputs[2])
     actual_gs.set_distances_at_angle(inputs[3])
-    assert actual_gs.distances == pytest.approx(expected_distances, rel=1e-4, abs=1e-6)
+    actual_distances_sorted = sorted(actual_gs.distances)
+    expected_distances_sorted = sorted(expected_distances)
+    assert actual_distances_sorted == pytest.approx(expected_distances_sorted, rel=1e-4, abs=1e-6)

--- a/src/diffpy/labpdfproc/tests/test_functions.py
+++ b/src/diffpy/labpdfproc/tests/test_functions.py
@@ -2,6 +2,22 @@ import pytest
 
 from diffpy.labpdfproc.functions import Gridded_circle
 
+params1 = [
+    ([0.5, 3, 1], {(0.0, -0.5), (0.0, 0.0), (0.5, 0.0), (-0.5, 0.0), (0.0, 0.5)}),
+    ([1, 4, 1], {(-0.333333, -0.333333), (0.333333, -0.333333), (-0.333333, 0.333333), (0.333333, 0.333333)}),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params1)
+def test_get_grid_points(inputs, expected):
+    expected_grid = expected
+    actual_gs = Gridded_circle(radius=inputs[0], n_points_on_diameter=inputs[1], mu=inputs[2])
+    actual_grid_sorted = sorted(actual_gs.grid)
+    expected_grid_sorted = sorted(expected_grid)
+    for actual_point, expected_point in zip(actual_grid_sorted, expected_grid_sorted):
+        assert actual_point == pytest.approx(expected_point, rel=1e-4, abs=1e-6)
+
+
 params2 = [
     ([1, 3, 1, 45], [0, 1.4142135, 1.4142135, 2, 2]),
     ([1, 3, 1, 90], [0, 0, 2, 2, 2]),


### PR DESCRIPTION
Tests passed assertion. Checked distances for both odd and even grid points (i.e., points on the circle, in the center, and at each quadrant) and for acute, right, and obtuse angles.