### PR TITLE
closes #24: check if args.input_file is specified

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -90,7 +90,12 @@ def main():
             )
 
         input_pattern = Diffraction_object(wavelength=wavelength)
-        xarray, yarray = loadData(filepath.name, unpack=True)
+        try:
+            xarray, yarray = loadData(filepath, unpack=True)
+        except Exception as e:
+            print(f"Non-readable data file {filepath}: {e}")
+            continue
+
         input_pattern.insert_scattering_quantity(
             xarray,
             yarray,


### PR DESCRIPTION
Initial commit

Specify input directory with default as cwd, glob all files in directory and write outputs
Skip non-readable files using loadData (try except and provide an error message)

(need suggestions) still need to implement the following: compute cve only one time. We probably need to split compute_cve function to achieve this, having one function compute cves using tth we defined, and a second function to interpolat across different tths for different input files.