### PR TITLE
closes #25: overload wavelength

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -62,7 +62,13 @@ def get_args():
 
 def main():
     args = get_args()
-    wavelength = WAVELENGTHS[args.anode_type]
+
+    wavelength = WAVELENGTHS["Mo"]
+    if args.wavelength:
+        wavelength = args.wavelength
+    elif args.anode_type:
+        wavelength = WAVELENGTHS[args.anode_type]
+
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"
     corrfilestem = filepath.stem + "_cve"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.user_functions import load_wavelength
+from diffpy.labpdfproc.tools import load_wavelength
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -63,7 +63,7 @@ def get_args():
 
 def main():
     args = get_args()
-    wavelength = load_wavelength(args, WAVELENGTHS)
+    wavelength = load_wavelength(args.wavelength, args.anode_type, WAVELENGTHS)
 
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
+from diffpy.labpdfproc.user_functions import load_wavelength
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -62,12 +63,7 @@ def get_args():
 
 def main():
     args = get_args()
-
-    wavelength = WAVELENGTHS["Mo"]
-    if args.wavelength:
-        wavelength = args.wavelength
-    elif args.anode_type:
-        wavelength = WAVELENGTHS[args.anode_type]
+    wavelength = load_wavelength(args, WAVELENGTHS)
 
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -64,7 +64,6 @@ def get_args():
 def main():
     args = get_args()
     args.wavelength = set_wavelength(args)
-
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"
     corrfilestem = filepath.stem + "_cve"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.tools import load_wavelength
+from diffpy.labpdfproc.tools import set_wavelength
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -63,7 +63,7 @@ def get_args():
 
 def main():
     args = get_args()
-    wavelength = load_wavelength(args.wavelength, args.anode_type, WAVELENGTHS)
+    args.wavelength = set_wavelength(args)
 
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"
@@ -82,7 +82,7 @@ def main():
             f"exists. Please rerun specifying -f if you want to overwrite it"
         )
 
-    input_pattern = Diffraction_object(wavelength=wavelength)
+    input_pattern = Diffraction_object(wavelength=args.wavelength)
     xarray, yarray = loadData(args.input_file, unpack=True)
     input_pattern.insert_scattering_quantity(
         xarray,
@@ -93,7 +93,7 @@ def main():
         metadata={"muD": args.mud, "anode_type": args.anode_type},
     )
 
-    absorption_correction = compute_cve(input_pattern, args.mud, wavelength)
+    absorption_correction = compute_cve(input_pattern, args.mud, args.wavelength)
     corrected_data = apply_corr(input_pattern, absorption_correction)
     corrected_data.name = f"Absorption corrected input_data: {input_pattern.name}"
     corrected_data.dump(f"{outfile}", xtype="tth")

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock
+
 import pytest
 
-from diffpy.labpdfproc.labpdfprocapp import WAVELENGTHS
-from diffpy.labpdfproc.tools import load_wavelength
+from diffpy.labpdfproc.tools import set_wavelength
+
+WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 
 params1 = [
     ([None, None], [0.71]),
@@ -12,7 +15,9 @@ params1 = [
 
 
 @pytest.mark.parametrize("inputs, expected", params1)
-def test_load_wavelengths(inputs, expected):
+def test_set_wavelength(inputs, expected):
     expected_wavelength = expected[0]
-    actual_wavelength = load_wavelength(inputs[0], inputs[1], WAVELENGTHS)
+    actual_args = MagicMock()
+    actual_args.wavelength, actual_args.anode_type = inputs[0], inputs[1]
+    actual_wavelength = set_wavelength(actual_args)
     assert actual_wavelength == expected_wavelength

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,0 +1,18 @@
+import pytest
+
+from diffpy.labpdfproc.labpdfprocapp import WAVELENGTHS
+from diffpy.labpdfproc.tools import load_wavelength
+
+params1 = [
+    ([None, None], [0.71]),
+    ([None, "Ag"], [0.59]),
+    ([0.25, "Ag"], [0.25]),
+    ([0.25, None], [0.25]),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params1)
+def test_load_wavelengths(inputs, expected):
+    expected_wavelength = expected[0]
+    actual_wavelength = load_wavelength(inputs[0], inputs[1], WAVELENGTHS)
+    assert actual_wavelength == expected_wavelength

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -20,10 +20,15 @@ def test_set_wavelength(inputs, expected):
     assert actual_wavelength == expected_wavelength
 
 
-def test_set_wavelength_bad():
+params3 = [
+    ([None, "invalid"]),
+    ([0, None]),
+    ([-1, "Mo"]),
+]
+
+
+@pytest.mark.parametrize("inputs", params3)
+def test_set_wavelength_bad(inputs):
     with pytest.raises(ValueError):
-        actual_args = argparse.Namespace(wavelength=None, anode_type="invalid")
-        actual_args.wavelength = set_wavelength(actual_args)
-    with pytest.raises(ValueError):
-        actual_args = argparse.Namespace(wavelength=0, anode_type=None)
+        actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
         actual_args.wavelength = set_wavelength(actual_args)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+import argparse
 
 import pytest
 
@@ -6,7 +6,7 @@ from diffpy.labpdfproc.tools import set_wavelength
 
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 
-params1 = [
+params2 = [
     ([None, None], [0.71]),
     ([None, "Ag"], [0.59]),
     ([0.25, "Ag"], [0.25]),
@@ -14,10 +14,9 @@ params1 = [
 ]
 
 
-@pytest.mark.parametrize("inputs, expected", params1)
+@pytest.mark.parametrize("inputs, expected", params2)
 def test_set_wavelength(inputs, expected):
     expected_wavelength = expected[0]
-    actual_args = MagicMock()
-    actual_args.wavelength, actual_args.anode_type = inputs[0], inputs[1]
+    actual_args = actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
     actual_wavelength = set_wavelength(actual_args)
     assert actual_wavelength == expected_wavelength

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -4,8 +4,6 @@ import pytest
 
 from diffpy.labpdfproc.tools import set_wavelength
 
-WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
-
 params2 = [
     ([None, None], [0.71]),
     ([None, "Ag"], [0.59]),
@@ -17,6 +15,15 @@ params2 = [
 @pytest.mark.parametrize("inputs, expected", params2)
 def test_set_wavelength(inputs, expected):
     expected_wavelength = expected[0]
-    actual_args = actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
+    actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
     actual_wavelength = set_wavelength(actual_args)
     assert actual_wavelength == expected_wavelength
+
+
+def test_set_wavelength_bad():
+    with pytest.raises(ValueError):
+        actual_args = argparse.Namespace(wavelength=None, anode_type="invalid")
+        actual_args.wavelength = set_wavelength(actual_args)
+    with pytest.raises(ValueError):
+        actual_args = argparse.Namespace(wavelength=0, anode_type=None)
+        actual_args.wavelength = set_wavelength(actual_args)

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -3,6 +3,22 @@ known_sources = [key for key in WAVELENGTHS.keys()]
 
 
 def set_wavelength(args):
+    """
+    Set the wavelength based on the given input arguments
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser
+
+    Returns
+    -------
+        float: the wavelength value
+
+    we raise an ValueError if the input wavelength is non-positive
+    or if the input anode_type is not one of the known sources
+
+    """
     if args.wavelength and args.wavelength <= 0:
         raise ValueError("Please rerun the program specifying a positive float number.")
     if not args.wavelength and args.anode_type and args.anode_type not in WAVELENGTHS:

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,20 +1,20 @@
-import sys
-
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
+known_sources = [key for key in WAVELENGTHS.keys()]
 
 
 def set_wavelength(args):
-    if args.wavelength and not isinstance(args.wavelength, float):
-        sys.exit("Please enter the wavelength as a float value.")
-    if not args.wavelength and args.anode_type and not (args.anode_type in WAVELENGTHS):
-        sys.exit(
-            "Please either specify a wavelength as a float value "
-            "or specify anode_type as one of 'Mo', 'Ag', or 'Cu'."
+    if args.wavelength and args.wavelength <= 0:
+        raise ValueError("Please rerun the program specifying a positive float number.")
+    if not args.wavelength and args.anode_type and args.anode_type not in WAVELENGTHS:
+        raise ValueError(
+            f"Invalid anode type {args.anode_type}. "
+            f"Please rerun the program to either specify a wavelength as a positive float number "
+            f"or specify anode_type as one of {known_sources}."
         )
 
-    wavelength = WAVELENGTHS["Mo"]
     if args.wavelength:
-        wavelength = args.wavelength
+        return args.wavelength
     elif args.anode_type:
-        wavelength = WAVELENGTHS[args.anode_type]
-    return wavelength
+        return WAVELENGTHS[args.anode_type]
+    else:
+        return WAVELENGTHS["Mo"]

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,7 +1,10 @@
-def load_wavelength(args_wavelength, args_anode_type, WAVELENGTHS):
+WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
+
+
+def set_wavelength(args):
     wavelength = WAVELENGTHS["Mo"]
-    if args_wavelength:
-        wavelength = args_wavelength
-    elif args_anode_type:
-        wavelength = WAVELENGTHS[args_anode_type]
+    if args.wavelength:
+        wavelength = args.wavelength
+    elif args.anode_type:
+        wavelength = WAVELENGTHS[args.anode_type]
     return wavelength

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,7 +1,17 @@
+import sys
+
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 
 
 def set_wavelength(args):
+    if args.wavelength and not isinstance(args.wavelength, float):
+        sys.exit("Please enter the wavelength as a float value.")
+    if not args.wavelength and args.anode_type and not (args.anode_type in WAVELENGTHS):
+        sys.exit(
+            "Please either specify a wavelength as a float value "
+            "or specify anode_type as one of 'Mo', 'Ag', or 'Cu'."
+        )
+
     wavelength = WAVELENGTHS["Mo"]
     if args.wavelength:
         wavelength = args.wavelength

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,0 +1,7 @@
+def load_wavelength(args_wavelength, args_anode_type, WAVELENGTHS):
+    wavelength = WAVELENGTHS["Mo"]
+    if args_wavelength:
+        wavelength = args_wavelength
+    elif args_anode_type:
+        wavelength = WAVELENGTHS[args_anode_type]
+    return wavelength

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -19,7 +19,7 @@ def set_wavelength(args):
     or if the input anode_type is not one of the known sources
 
     """
-    if args.wavelength and args.wavelength <= 0:
+    if args.wavelength is not None and args.wavelength <= 0:
         raise ValueError("Please rerun the program specifying a positive float number.")
     if not args.wavelength and args.anode_type and args.anode_type not in WAVELENGTHS:
         raise ValueError(

--- a/src/diffpy/labpdfproc/user_functions.py
+++ b/src/diffpy/labpdfproc/user_functions.py
@@ -1,7 +1,0 @@
-def load_wavelength(args, WAVELENGTHS):
-    wavelength = WAVELENGTHS["Mo"]
-    if args.wavelength:
-        wavelength = args.wavelength
-    elif args.anode_type:
-        wavelength = WAVELENGTHS[args.anode_type]
-    return wavelength

--- a/src/diffpy/labpdfproc/user_functions.py
+++ b/src/diffpy/labpdfproc/user_functions.py
@@ -1,0 +1,7 @@
+def load_wavelength(args, WAVELENGTHS):
+    wavelength = WAVELENGTHS["Mo"]
+    if args.wavelength:
+        wavelength = args.wavelength
+    elif args.anode_type:
+        wavelength = WAVELENGTHS[args.anode_type]
+    return wavelength


### PR DESCRIPTION
Initial commit for overloading wavelength

Code does the following: first set wavelength to default as anode-type Mo, if args.wavelength is provided then set it to args.wavelength, otherwise if anode-type is provided set it to that.

I can wrap this up into a function if we prefer that