### PR TITLE
closes #26: initial commit on loading user-specified pairs into args

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.tools import load_additional_info
+from diffpy.labpdfproc.tools import load_user_metadata
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -37,7 +37,7 @@ def get_args():
     p.add_argument(
         "-x",
         "--xtype",
-        help=f"the quantity on the independnt variable axis. allowed "
+        help=f"the quantity on the independent variable axis. allowed "
         f"values: {*XQUANTITIES, }. If not specified then two-theta "
         f"is assumed for the independent variable. Only implemented for "
         f"tth currently",
@@ -55,15 +55,15 @@ def get_args():
         "-f",
         "--force-overwrite",
         action="store_true",
-        help="outputs will not overwrite existing file unless --force is spacified",
+        help="outputs will not overwrite existing file unless --force is specified",
     )
     p.add_argument(
-        "-add",
-        "--additional-info",
+        "-u",
+        "--user-metadata",
         metavar=("KEY=VALUE"),
         action="append",
         help="specify key-value pairs to be loaded into metadata by using key=value. "
-        "You can specify multiple paris by calling -add multiple times.",
+        "You can specify multiple paris by calling -u multiple times.",
     )
     args = p.parse_args()
     return args
@@ -71,7 +71,7 @@ def get_args():
 
 def main():
     args = get_args()
-    args = load_additional_info(args)
+    args = load_user_metadata(args)
     wavelength = WAVELENGTHS[args.anode_type]
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
+from diffpy.labpdfproc.tools import load_additional_info
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -56,12 +57,21 @@ def get_args():
         action="store_true",
         help="outputs will not overwrite existing file unless --force is spacified",
     )
+    p.add_argument(
+        "-add",
+        "--additional-info",
+        metavar=("KEY=VALUE"),
+        action="append",
+        help="specify key-value pairs to be loaded into metadata. You can specify multiple "
+        "paris by calling -add multiple times",
+    )
     args = p.parse_args()
     return args
 
 
 def main():
     args = get_args()
+    args = load_additional_info(args)
     wavelength = WAVELENGTHS[args.anode_type]
     filepath = Path(args.input_file)
     outfilestem = filepath.stem + "_corrected"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -62,8 +62,8 @@ def get_args():
         "--additional-info",
         metavar=("KEY=VALUE"),
         action="append",
-        help="specify key-value pairs to be loaded into metadata. You can specify multiple "
-        "paris by calling -add multiple times",
+        help="specify key-value pairs to be loaded into metadata by using key=value. "
+        "You can specify multiple paris by calling -add multiple times.",
     )
     args = p.parse_args()
     return args

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -60,10 +60,11 @@ def get_args():
     p.add_argument(
         "-u",
         "--user-metadata",
-        metavar=("KEY=VALUE"),
-        action="append",
-        help="specify key-value pairs to be loaded into metadata by using key=value. "
-        "You can specify multiple paris by calling -u multiple times.",
+        metavar="KEY=VALUE",
+        nargs="+",
+        help="specify (multiple) key-value pairs to be loaded into metadata by using key=value. "
+        "Do not leave whitespaces before or after = sign. "
+        "If a key or value contains whitespace, you should define it with quotes. ",
     )
     args = p.parse_args()
     return args

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -5,29 +5,6 @@ import pytest
 
 from diffpy.labpdfproc.tools import load_user_metadata, set_wavelength
 
-params5 = [
-    ([[]], []),
-    ([["toast=for breakfast"]], [["toast", "for breakfast"]]),
-    ([["mylist=[1,2,3.0]"]], [["mylist", "[1,2,3.0]"]]),
-    ([["weather=rainy", "day=tuesday"]], [["weather", "rainy"], ["day", "tuesday"]]),
-]
-
-
-@pytest.mark.parametrize("inputs, expected", params5)
-def test_load_user_metadata(inputs, expected):
-    actual_parser = ArgumentParser()
-    actual_parser.add_argument("-u", "--user-metadata", action="append", metavar="KEY=VALUE", nargs="+")
-    actual_args = actual_parser.parse_args([])
-    expected_parser = ArgumentParser()
-    expected_args = expected_parser.parse_args([])
-
-    setattr(actual_args, "user_metadata", inputs[0])
-    actual_args = load_user_metadata(actual_args)
-    for expected_pair in expected:
-        setattr(expected_args, expected_pair[0], expected_pair[1])
-    assert actual_args == expected_args
-
-
 params2 = [
     ([None, None], [0.71]),
     ([None, "Ag"], [0.59]),
@@ -56,3 +33,26 @@ def test_set_wavelength_bad(inputs):
     with pytest.raises(ValueError):
         actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
         actual_args.wavelength = set_wavelength(actual_args)
+
+
+params5 = [
+    ([[]], []),
+    ([["toast=for breakfast"]], [["toast", "for breakfast"]]),
+    ([["mylist=[1,2,3.0]"]], [["mylist", "[1,2,3.0]"]]),
+    ([["weather=rainy", "day=tuesday"]], [["weather", "rainy"], ["day", "tuesday"]]),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params5)
+def test_load_user_metadata(inputs, expected):
+    actual_parser = ArgumentParser()
+    actual_parser.add_argument("-u", "--user-metadata", action="append", metavar="KEY=VALUE", nargs="+")
+    actual_args = actual_parser.parse_args([])
+    expected_parser = ArgumentParser()
+    expected_args = expected_parser.parse_args([])
+
+    setattr(actual_args, "user_metadata", inputs[0])
+    actual_args = load_user_metadata(actual_args)
+    for expected_pair in expected:
+        setattr(expected_args, expected_pair[0], expected_pair[1])
+    assert actual_args == expected_args

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,0 +1,30 @@
+from argparse import ArgumentParser
+
+import pytest
+
+from diffpy.labpdfproc.tools import load_additional_info
+
+params5 = [
+    ([], []),
+    ([["weather=rainy"]], [["weather", "rainy"]]),
+    ([["weather=rainy", "day=tuesday"]], [["weather", "rainy"], ["day", "tuesday"]]),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params5)
+def test_load_additional_info(inputs, expected):
+    actual_parser = ArgumentParser()
+    actual_parser.add_argument("-add", "--additional-info", action="append", metavar=("KEY=VALUE"))
+    actual_args = actual_parser.parse_args([])
+    expected_parser = ArgumentParser()
+    expected_args = expected_parser.parse_args([])
+
+    if not inputs:
+        actual_args = load_additional_info(actual_args)
+        assert actual_args == expected_args
+    else:
+        setattr(actual_args, "additional_info", inputs[0])
+        actual_args = load_additional_info(actual_args)
+        for expected_pair in expected:
+            setattr(expected_args, expected_pair[0], expected_pair[1])
+        assert actual_args == expected_args

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -2,11 +2,12 @@ from argparse import ArgumentParser
 
 import pytest
 
-from diffpy.labpdfproc.tools import load_additional_info
+from diffpy.labpdfproc.tools import load_user_metadata
 
 params5 = [
-    ([], []),
-    ([["weather=rainy"]], [["weather", "rainy"]]),
+    ([[]], []),
+    ([["toast=for breakfast"]], [["toast", "for breakfast"]]),
+    ([["mylist=[1,2,3.0]"]], [["mylist", "[1,2,3.0]"]]),
     ([["weather=rainy", "day=tuesday"]], [["weather", "rainy"], ["day", "tuesday"]]),
 ]
 
@@ -14,17 +15,13 @@ params5 = [
 @pytest.mark.parametrize("inputs, expected", params5)
 def test_load_additional_info(inputs, expected):
     actual_parser = ArgumentParser()
-    actual_parser.add_argument("-add", "--additional-info", action="append", metavar=("KEY=VALUE"))
+    actual_parser.add_argument("-u", "--user-metadata", action="append", metavar=("KEY=VALUE"))
     actual_args = actual_parser.parse_args([])
     expected_parser = ArgumentParser()
     expected_args = expected_parser.parse_args([])
 
-    if not inputs:
-        actual_args = load_additional_info(actual_args)
-        assert actual_args == expected_args
-    else:
-        setattr(actual_args, "additional_info", inputs[0])
-        actual_args = load_additional_info(actual_args)
-        for expected_pair in expected:
-            setattr(expected_args, expected_pair[0], expected_pair[1])
-        assert actual_args == expected_args
+    setattr(actual_args, "user_metadata", inputs[0])
+    actual_args = load_user_metadata(actual_args)
+    for expected_pair in expected:
+        setattr(expected_args, expected_pair[0], expected_pair[1])
+    assert actual_args == expected_args

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -13,9 +13,9 @@ params5 = [
 
 
 @pytest.mark.parametrize("inputs, expected", params5)
-def test_load_additional_info(inputs, expected):
+def test_load_user_metadata(inputs, expected):
     actual_parser = ArgumentParser()
-    actual_parser.add_argument("-u", "--user-metadata", action="append", metavar=("KEY=VALUE"))
+    actual_parser.add_argument("-u", "--user-metadata", action="append", metavar="KEY=VALUE", nargs="+")
     actual_args = actual_parser.parse_args([])
     expected_parser = ArgumentParser()
     expected_args = expected_parser.parse_args([])

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -2,39 +2,6 @@ WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 known_sources = [key for key in WAVELENGTHS.keys()]
 
 
-def load_key_value_pair(s):
-    items = s.split("=")
-    key = items[0].strip()
-    if len(items) > 1:
-        value = "=".join(items[1:])
-    return (key, value)
-
-
-def load_user_metadata(args):
-    if args.user_metadata:
-        for item in args.user_metadata:
-            if "=" not in item:
-                raise ValueError("please provide key-value pairs in the format key=value.")
-            key, value = load_key_value_pair(item)
-            setattr(args, key, value)
-    delattr(args, "user_metadata")
-    return args
-
-
-# Notes, can ignore
-# ideal inputs: "key1=value1" "key2=value2"
-# (different pairs are separated by white spaces, key and value are separated by =)
-
-# question 1: white spaces in key, value, both?
-# if value contains whitespace, you can specify key="value value" or "key=value value"
-# if key contains whitespace, for example, you have "key key=value",
-# then you can access like getattr(args, 'key key'), but we dont recommend this
-
-# question 2: more than one =?
-# if i have key is hello, value is hello=world, then i can have hello=hello=world to process okay
-# if i have = in key then it's still processing as value => would this be an issue?
-
-
 def set_wavelength(args):
     """
     Set the wavelength based on the given input arguments
@@ -67,3 +34,36 @@ def set_wavelength(args):
         return WAVELENGTHS[args.anode_type]
     else:
         return WAVELENGTHS["Mo"]
+
+
+def _load_key_value_pair(s):
+    items = s.split("=")
+    key = items[0].strip()
+    if len(items) > 1:
+        value = "=".join(items[1:])
+    return (key, value)
+
+
+def load_user_metadata(args):
+    if args.user_metadata:
+        for item in args.user_metadata:
+            if "=" not in item:
+                raise ValueError("please provide key-value pairs in the format key=value.")
+            key, value = _load_key_value_pair(item)
+            setattr(args, key, value)
+    delattr(args, "user_metadata")
+    return args
+
+
+# Notes, can ignore
+# ideal inputs: "key1=value1" "key2=value2"
+# (different pairs are separated by white spaces, key and value are separated by =)
+
+# question 1: white spaces in key, value, both?
+# if value contains whitespace, you can specify key="value value" or "key=value value"
+# if key contains whitespace, for example, you have "key key=value",
+# then you can access like getattr(args, 'key key'), but we dont recommend this
+
+# question 2: more than one =?
+# if i have key is hello, value is hello=world, then i can have hello=hello=world to process okay
+# if i have = in key then it's still processing as value => would this be an issue?

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,0 +1,7 @@
+def load_additional_info(args):
+    if args.additional_info:
+        for item in args.additional_info:
+            key, value = item.split("=")
+            setattr(args, key, value)
+    delattr(args, "additional_info")
+    return args

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,7 +1,19 @@
-def load_additional_info(args):
-    if args.additional_info:
-        for item in args.additional_info:
-            key, value = item.split("=")
+import sys
+
+
+def load_user_metadata(args):
+    if args.user_metadata:
+        for item in args.user_metadata:
+            if not item:
+                sys.exit(
+                    "please provide at least one key-value pair in the format key=value. "
+                    "you can exclude -add if you don't want to provide additional info."
+                )
+            if "=" not in item:
+                sys.exit("please provide key-value pairs in the format key=value.")
+            key, value = item.split("=", 1)
+            # if "=" in value:
+            #    sys.exit("please use only one equals sign for key=value.")
             setattr(args, key, value)
-    delattr(args, "additional_info")
+    delattr(args, "user_metadata")
     return args

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,19 +1,31 @@
-import sys
+def load_key_value_pair(s):
+    items = s.split("=")
+    key = items[0].strip()
+    if len(items) > 1:
+        value = "=".join(items[1:])
+    return (key, value)
 
 
 def load_user_metadata(args):
     if args.user_metadata:
         for item in args.user_metadata:
-            if not item:
-                sys.exit(
-                    "please provide at least one key-value pair in the format key=value. "
-                    "you can exclude -add if you don't want to provide additional info."
-                )
             if "=" not in item:
-                sys.exit("please provide key-value pairs in the format key=value.")
-            key, value = item.split("=", 1)
-            # if "=" in value:
-            #    sys.exit("please use only one equals sign for key=value.")
+                raise ValueError("please provide key-value pairs in the format key=value.")
+            key, value = load_key_value_pair(item)
             setattr(args, key, value)
     delattr(args, "user_metadata")
     return args
+
+
+# Notes, can ignore
+# ideal inputs: "key1=value1" "key2=value2"
+# (different pairs are separated by white spaces, key and value are separated by =)
+
+# question 1: white spaces in key, value, both?
+# if value contains whitespace, you can specify key="value value" or "key=value value"
+# if key contains whitespace, for example, you have "key key=value",
+# then you can access like getattr(args, 'key key'), but we dont recommend this
+
+# question 2: more than one =?
+# if i have key is hello, value is hello=world, then i can have hello=hello=world to process okay
+# if i have = in key then it's still processing as value => would this be an issue?


### PR DESCRIPTION
Initial commit on loading extra pairs into args, tests not written yet.

The pairs are not written into the header of output files for now, as required in the issue description, but this functionality should be addressed from https://github.com/diffpy/diffpy.labpdfproc/issues/27?