### PR TITLE
yucongalicechen output dir

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
+from diffpy.labpdfproc.tools import set_output_directory
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -65,13 +66,11 @@ def main():
     args = get_args()
     wavelength = WAVELENGTHS[args.anode_type]
     filepath = Path(args.input_file)
-    output_dir = Path(args.output_directory).resolve() if args.output_directory else Path.cwd()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    args.output_directory = output_dir
+    args.output_directory = set_output_directory(args)
     outfilestem = filepath.stem + "_corrected"
     corrfilestem = filepath.stem + "_cve"
-    outfile = output_dir / (outfilestem + ".chi")
-    corrfile = output_dir / (corrfilestem + ".chi")
+    outfile = args.output_directory / (outfilestem + ".chi")
+    corrfile = args.output_directory / (corrfilestem + ".chi")
 
     if outfile.exists() and not args.force_overwrite:
         sys.exit(

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -29,14 +29,15 @@ def get_args():
     p.add_argument(
         "-o",
         "--output-directory",
-        help="the name of the output directory. If it doesn't exist it "
-        "will be created.  Not currently implemented",
+        help="the name of the output directory. If not specified "
+        "then corrected files will be written to the current directory."
+        "If the specified directory doesn't exist it will be created.",
         default=None,
     )
     p.add_argument(
         "-x",
         "--xtype",
-        help=f"the quantity on the independnt variable axis. allowed "
+        help=f"the quantity on the independent variable axis. allowed "
         f"values: {*XQUANTITIES, }. If not specified then two-theta "
         f"is assumed for the independent variable. Only implemented for "
         f"tth currently",
@@ -54,7 +55,7 @@ def get_args():
         "-f",
         "--force-overwrite",
         action="store_true",
-        help="outputs will not overwrite existing file unless --force is spacified",
+        help="outputs will not overwrite existing file unless --force is specified",
     )
     args = p.parse_args()
     return args

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -64,8 +64,9 @@ def main():
     args = get_args()
     wavelength = WAVELENGTHS[args.anode_type]
     filepath = Path(args.input_file)
-    output_dir = Path(args.output_directory) if args.output_directory else Path("corrected")
+    output_dir = Path(args.output_directory).resolve() if args.output_directory else Path.cwd()
     output_dir.mkdir(parents=True, exist_ok=True)
+    args.output_directory = output_dir
     outfilestem = filepath.stem + "_corrected"
     corrfilestem = filepath.stem + "_cve"
     outfile = output_dir / (outfilestem + ".chi")

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -64,10 +64,12 @@ def main():
     args = get_args()
     wavelength = WAVELENGTHS[args.anode_type]
     filepath = Path(args.input_file)
+    output_dir = Path(args.output_directory) if args.output_directory else Path("corrected")
+    output_dir.mkdir(parents=True, exist_ok=True)
     outfilestem = filepath.stem + "_corrected"
     corrfilestem = filepath.stem + "_cve"
-    outfile = Path(outfilestem + ".chi")
-    corrfile = Path(corrfilestem + ".chi")
+    outfile = output_dir / (outfilestem + ".chi")
+    corrfile = output_dir / (corrfilestem + ".chi")
 
     if outfile.exists() and not args.force_overwrite:
         sys.exit(

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.tools import known_sources, set_wavelength, set_output_directory
+from diffpy.labpdfproc.tools import known_sources, set_output_directory, set_wavelength
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -9,7 +9,6 @@ params1 = [
     ([None], [Path.cwd().resolve()]),
     (["."], [Path.cwd().resolve()]),
     (["new_dir"], [Path.cwd().resolve() / "new_dir"]),
-    (["new_dir.py"], [Path.cwd().resolve() / "new_dir.py"]),
     (["existing_dir"], [Path.cwd().resolve() / "existing_dir"]),
 ]
 

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -28,8 +28,7 @@ def test_set_output_directory(inputs, expected):
 
 def test_set_output_directory_bad():
     existing_file = Path().cwd().resolve() / "existing_file.py"
-    with open(existing_file, "w"):
-        pass
+    existing_file.touch()
 
     actual_args = argparse.Namespace(output_directory="existing_file.py")
     with pytest.raises(FileExistsError):

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -15,5 +15,11 @@ params1 = [
 def test_set_output_directory(inputs, expected):
     expected_output_directory = expected[0]
     actual_args = argparse.Namespace(output_directory=inputs[0])
-    actual_output_directory = set_output_directory(actual_args)
-    assert actual_output_directory == expected_output_directory
+    actual_args.output_directory = set_output_directory(actual_args)
+    assert actual_args.output_directory == expected_output_directory
+    assert Path(actual_args.output_directory).exists()
+    assert Path(actual_args.output_directory).is_dir()
+
+    with pytest.raises(FileExistsError):
+        actual_args = argparse.Namespace(output_directory="test_tools.py")
+        actual_args.output_directory = set_output_directory(actual_args)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+from diffpy.labpdfproc.tools import set_output_directory
+
+params1 = [
+    ([None], [Path.cwd()]),
+    (["corrected"], [Path("corrected").resolve()]),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params1)
+def test_set_output_directory(inputs, expected):
+    expected_output_directory = expected[0]
+    actual_args = argparse.Namespace(output_directory=inputs[0])
+    actual_output_directory = set_output_directory(actual_args)
+    assert actual_output_directory == expected_output_directory

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -28,11 +28,11 @@ def test_set_output_directory(inputs, expected):
 
 
 def test_set_output_directory_bad():
-    existing_dir = Path().cwd().resolve() / "existing_dir.py"
-    with open(existing_dir, "w"):
+    existing_file = Path().cwd().resolve() / "existing_file.py"
+    with open(existing_file, "w"):
         pass
 
-    actual_args = argparse.Namespace(output_directory="existing_dir.py")
+    actual_args = argparse.Namespace(output_directory="existing_file.py")
     with pytest.raises(FileExistsError):
         actual_args.output_directory = set_output_directory(actual_args)
         assert Path(actual_args.output_directory).exists()

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,24 +1,26 @@
 import argparse
+import os
 from pathlib import Path
 
 import pytest
 
-from diffpy.labpdfproc.tools import set_output_directory, set_wavelength, known_sources
+from diffpy.labpdfproc.tools import known_sources, set_output_directory, set_wavelength
 
 params1 = [
-    ([None], [Path.cwd().resolve()]),
-    (["."], [Path.cwd().resolve()]),
-    (["new_dir"], [Path.cwd().resolve() / "new_dir"]),
-    (["existing_dir"], [Path.cwd().resolve() / "existing_dir"]),
+    ([None], ["."]),
+    (["."], ["."]),
+    (["new_dir"], ["new_dir"]),
+    (["existing_dir"], ["existing_dir"]),
 ]
 
 
 @pytest.mark.parametrize("inputs, expected", params1)
-def test_set_output_directory(inputs, expected):
-    existing_dir = Path().cwd().resolve() / "existing_dir"
+def test_set_output_directory(inputs, expected, tmpdir):
+    existing_dir = Path(tmpdir) / "existing_dir"
     existing_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(tmpdir)
 
-    expected_output_directory = expected[0]
+    expected_output_directory = Path(tmpdir).resolve() / expected[0]
     actual_args = argparse.Namespace(output_directory=inputs[0])
     actual_args.output_directory = set_output_directory(actual_args)
     assert actual_args.output_directory == expected_output_directory
@@ -26,9 +28,10 @@ def test_set_output_directory(inputs, expected):
     assert Path(actual_args.output_directory).is_dir()
 
 
-def test_set_output_directory_bad():
-    existing_file = Path().cwd().resolve() / "existing_file.py"
+def test_set_output_directory_bad(tmpdir):
+    existing_file = Path(tmpdir) / "existing_file.py"
     existing_file.touch()
+    os.chdir(tmpdir)
 
     actual_args = argparse.Namespace(output_directory="existing_file.py")
     with pytest.raises(FileExistsError):

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -6,13 +6,19 @@ import pytest
 from diffpy.labpdfproc.tools import set_output_directory
 
 params1 = [
-    ([None], [Path.cwd()]),
-    (["corrected"], [Path("corrected").resolve()]),
+    ([None], [Path.cwd().resolve()]),
+    (["."], [Path.cwd().resolve()]),
+    (["new_dir"], [Path.cwd().resolve() / "new_dir"]),
+    (["new_dir.py"], [Path.cwd().resolve() / "new_dir.py"]),
+    (["existing_dir"], [Path.cwd().resolve() / "existing_dir"]),
 ]
 
 
 @pytest.mark.parametrize("inputs, expected", params1)
 def test_set_output_directory(inputs, expected):
+    existing_dir = Path().cwd().resolve() / "existing_dir"
+    existing_dir.mkdir(parents=True, exist_ok=True)
+
     expected_output_directory = expected[0]
     actual_args = argparse.Namespace(output_directory=inputs[0])
     actual_args.output_directory = set_output_directory(actual_args)
@@ -20,6 +26,14 @@ def test_set_output_directory(inputs, expected):
     assert Path(actual_args.output_directory).exists()
     assert Path(actual_args.output_directory).is_dir()
 
+
+def test_set_output_directory_bad():
+    existing_dir = Path().cwd().resolve() / "existing_dir.py"
+    with open(existing_dir, "w"):
+        pass
+
+    actual_args = argparse.Namespace(output_directory="existing_dir.py")
     with pytest.raises(FileExistsError):
-        actual_args = argparse.Namespace(output_directory="test_tools.py")
         actual_args.output_directory = set_output_directory(actual_args)
+        assert Path(actual_args.output_directory).exists()
+        assert not Path(actual_args.output_directory).is_dir()

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def set_output_directory(args):
+    output_dir = Path(args.output_directory).resolve() if args.output_directory else Path.cwd()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -8,7 +8,7 @@ def set_output_directory(args):
     Parameters
     ----------
     args argparse.Namespace
-        input arguments provided by the user
+        the arguments from the parser
 
     Returns
     -------
@@ -18,9 +18,8 @@ def set_output_directory(args):
     If user provides an output directory, use it.
     Otherwise, we set it to the current directory if nothing is provided.
     We then create the directory if it does not exist.
-    If the provided directory is an existed file then we raise the FileExistsError.
 
     """
-    output_dir = Path(args.output_directory).resolve() if args.output_directory else Path.cwd()
+    output_dir = Path(args.output_directory).resolve() if args.output_directory else Path.cwd().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -2,6 +2,25 @@ from pathlib import Path
 
 
 def set_output_directory(args):
+    """
+    set the output directory based on the given input arguments
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        input arguments provided by the user
+
+    Returns
+    -------
+    pathlib.PosixPath that contains the full path of the output directory
+
+    it is determined as follows:
+    If user provides an output directory, use it.
+    Otherwise, we set it to the current directory if nothing is provided.
+    We then create the directory if it does not exist.
+    If the provided directory is an existed file then we raise the FileExistsError.
+
+    """
     output_dir = Path(args.output_directory).resolve() if args.output_directory else Path.cwd()
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir


### PR DESCRIPTION
closes #22

- initial commit
- changed output_dir to absolute path, changed default to cwd, updated args.output_directory as output directory we defined
- edited help message
- Wrap up set_output_directory as a function and include tests functions
- included docstring and more tests
- added more tests for existing dir and existing file
- added more tests for existing dir and existing file
- deleted the unnecessary test case
- changed to existing_file.touch()
- tests for error messages
- adding richer tests of exception raising
- tweaking help messages in parser for wavelengths
- tweaking tests
