### PR TITLE
closes #25: update wavelength function

### DIFF
--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 
 import pytest
 
@@ -33,5 +34,5 @@ params3 = [
 @pytest.mark.parametrize("inputs, msg", params3)
 def test_set_wavelength_bad(inputs, msg):
     actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
-    with pytest.raises(ValueError, match=msg[0]):
+    with pytest.raises(ValueError, match=re.escape(msg[0])):
         actual_args.wavelength = set_wavelength(actual_args)

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -20,12 +20,12 @@ def set_wavelength(args):
 
     """
     if args.wavelength is not None and args.wavelength <= 0:
-        raise ValueError("Please rerun the program specifying a positive float number.")
+        raise ValueError(
+            "No valid wavelength. Please rerun specifying a known anode_type or a positive wavelength"
+        )
     if not args.wavelength and args.anode_type and args.anode_type not in WAVELENGTHS:
         raise ValueError(
-            f"Invalid anode type {args.anode_type}. "
-            f"Please rerun the program to either specify a wavelength as a positive float number "
-            f"or specify anode_type as one of {known_sources}."
+            f"Anode type not recognized. please rerun specifying an anode_type from {*known_sources, }"
         )
 
     if args.wavelength:


### PR DESCRIPTION
We refer {*known_sources, } which gives the output ('Mo', ...), do we prefer ['Mo', ...] or do we not have a preference about this?