### PR TITLE
closes #27: initial commit on loading metadata

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.tools import known_sources, set_output_directory, set_wavelength
+from diffpy.labpdfproc.tools import known_sources, load_metadata, set_output_directory, set_wavelength
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -92,7 +92,7 @@ def main():
         "tth",
         scat_quantity="x-ray",
         name=str(args.input_file),
-        metadata={"muD": args.mud, "anode_type": args.anode_type},
+        metadata=load_metadata(args),
     )
 
     absorption_correction = compute_cve(input_pattern, args.mud, args.wavelength)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from diffpy.labpdfproc.tools import known_sources, set_output_directory, set_wavelength
+from diffpy.labpdfproc.tools import known_sources, load_metadata, set_output_directory, set_wavelength
 
 params1 = [
     ([None], ["."]),
@@ -76,3 +76,61 @@ def test_set_wavelength_bad(inputs, msg):
     actual_args = argparse.Namespace(wavelength=inputs[0], anode_type=inputs[1])
     with pytest.raises(ValueError, match=re.escape(msg[0])):
         actual_args.wavelength = set_wavelength(actual_args)
+
+
+params6 = [
+    (
+        ["2.5", "zro2_mo.xy", "Mo", "0.71", "output_directory", "tth", "tth", False],
+        [
+            {
+                "mud": 2.5,
+                "input_file": "zro2_mo.xy",
+                "anode_type": "Mo",
+                "wavelength": 0.71,
+                "output_directory": "output_directory",
+                "xtype": "tth",
+                "output_correction": "tth",
+                "force_overwrite": False,
+            }
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params6)
+def test_load_metadata(inputs, expected):
+    expected_metadata = expected[0]
+
+    actual_parser = argparse.ArgumentParser()
+    actual_parser.add_argument("--mud", type=float)
+    actual_parser.add_argument("--input_file")
+    actual_parser.add_argument("--anode_type")
+    actual_parser.add_argument("--wavelength", type=float)
+    actual_parser.add_argument("--output_directory")
+    actual_parser.add_argument("--xtype")
+    actual_parser.add_argument("--output_correction")
+    actual_parser.add_argument("--force_overwrite")
+
+    actual_args = actual_parser.parse_args(
+        [
+            "--mud",
+            inputs[0],
+            "--input_file",
+            inputs[1],
+            "--anode_type",
+            inputs[2],
+            "--wavelength",
+            inputs[3],
+            "--output_directory",
+            inputs[4],
+            "--xtype",
+            inputs[5],
+            "--output_correction",
+            inputs[6],
+            "--force_overwrite",
+            inputs[7],
+        ]
+    )
+
+    actual_metadata = load_metadata(actual_args)
+    assert actual_metadata == expected_metadata

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -60,3 +60,18 @@ def set_wavelength(args):
         return WAVELENGTHS[args.anode_type]
     else:
         return WAVELENGTHS["Mo"]
+
+
+def load_metadata(args):
+    """
+    Load metadata from arguments
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser
+    Returns
+    -------
+    A dictionary with all arguments from the parser
+    """
+    metadata = vars(args)
+    return metadata


### PR DESCRIPTION
- Initial commit: Define vars(args) to load metadata into DO. wrote a basic test.
- I don't know if I overtest/undertest this. For example it seems that input_file, anode_type are both storing strings (or None), so it seems that it's enough to test one of these cases. Also, I need to test for True cases for force_overwrite. So I would say maybe instead of writing them all out, it's enough to test for string, float, and bool (3 arguments in total)?