### PR TITLE
input file list

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -21,7 +21,7 @@ def get_args(override_cli_inputs=None):
         "data-files in that directory will be processed. Examples of valid "
         "inputs are 'file.xy', 'data/file.xy', 'file.xy, data/file.xy', "
         "'.' (load everything in the current directory), 'data' (load"
-        "everything in the folder ./data', 'data/file_list.txt' (load"
+        "everything in the folder ./data), 'data/file_list.txt' (load"
         " the list of files contained in the text-file called "
         "file_list.txt that can be found in the folder ./data).",
     )

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -1,9 +1,14 @@
 import sys
 from argparse import ArgumentParser
-from pathlib import Path
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.tools import known_sources, load_user_metadata, set_output_directory, set_wavelength
+from diffpy.labpdfproc.tools import (
+    known_sources,
+    load_user_metadata,
+    set_input_lists,
+    set_output_directory,
+    set_wavelength,
+)
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -89,45 +94,46 @@ def get_args(override_cli_inputs=None):
 
 def main():
     args = get_args()
+    args = set_input_lists(args)
     args.output_directory = set_output_directory(args)
     args.wavelength = set_wavelength(args)
     args = load_user_metadata(args)
 
-    filepath = Path(args.input_file)
-    outfilestem = filepath.stem + "_corrected"
-    corrfilestem = filepath.stem + "_cve"
-    outfile = args.output_directory / (outfilestem + ".chi")
-    corrfile = args.output_directory / (corrfilestem + ".chi")
+    for filepath in args.input_directory:
+        outfilestem = filepath.stem + "_corrected"
+        corrfilestem = filepath.stem + "_cve"
+        outfile = args.output_directory / (outfilestem + ".chi")
+        corrfile = args.output_directory / (corrfilestem + ".chi")
 
-    if outfile.exists() and not args.force_overwrite:
-        sys.exit(
-            f"Output file {str(outfile)} already exists. Please rerun "
-            f"specifying -f if you want to overwrite it."
+        if outfile.exists() and not args.force_overwrite:
+            sys.exit(
+                f"Output file {str(outfile)} already exists. Please rerun "
+                f"specifying -f if you want to overwrite it."
+            )
+        if corrfile.exists() and args.output_correction and not args.force_overwrite:
+            sys.exit(
+                f"Corrections file {str(corrfile)} was requested and already "
+                f"exists. Please rerun specifying -f if you want to overwrite it."
+            )
+
+        input_pattern = Diffraction_object(wavelength=args.wavelength)
+        xarray, yarray = loadData(args.input_file, unpack=True)
+        input_pattern.insert_scattering_quantity(
+            xarray,
+            yarray,
+            "tth",
+            scat_quantity="x-ray",
+            name=str(args.input_file),
+            metadata={"muD": args.mud, "anode_type": args.anode_type},
         )
-    if corrfile.exists() and args.output_correction and not args.force_overwrite:
-        sys.exit(
-            f"Corrections file {str(corrfile)} was requested and already "
-            f"exists. Please rerun specifying -f if you want to overwrite it."
-        )
 
-    input_pattern = Diffraction_object(wavelength=args.wavelength)
-    xarray, yarray = loadData(args.input_file, unpack=True)
-    input_pattern.insert_scattering_quantity(
-        xarray,
-        yarray,
-        "tth",
-        scat_quantity="x-ray",
-        name=str(args.input_file),
-        metadata={"muD": args.mud, "anode_type": args.anode_type},
-    )
+        absorption_correction = compute_cve(input_pattern, args.mud, args.wavelength)
+        corrected_data = apply_corr(input_pattern, absorption_correction)
+        corrected_data.name = f"Absorption corrected input_data: {input_pattern.name}"
+        corrected_data.dump(f"{outfile}", xtype="tth")
 
-    absorption_correction = compute_cve(input_pattern, args.mud, args.wavelength)
-    corrected_data = apply_corr(input_pattern, absorption_correction)
-    corrected_data.name = f"Absorption corrected input_data: {input_pattern.name}"
-    corrected_data.dump(f"{outfile}", xtype="tth")
-
-    if args.output_correction:
-        absorption_correction.dump(f"{corrfile}", xtype="tth")
+        if args.output_correction:
+            absorption_correction.dump(f"{corrfile}", xtype="tth")
 
 
 if __name__ == "__main__":

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
 from diffpy.labpdfproc.tools import (
+    expand_list_file,
     known_sources,
     load_user_metadata,
     set_input_lists,
@@ -94,6 +95,7 @@ def get_args(override_cli_inputs=None):
 
 def main():
     args = get_args()
+    args = expand_list_file(args)
     args = set_input_lists(args)
     args.output_directory = set_output_directory(args)
     args.wavelength = set_wavelength(args)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -27,6 +27,9 @@ params_input = [
     (  # glob input directory
         ["./input_dir"],
         [
+            "./good_data.chi",
+            "./good_data.xy",
+            "./good_data.txt",
             "input_dir/good_data.chi",
             "input_dir/good_data.xy",
             "input_dir/good_data.txt",
@@ -69,7 +72,7 @@ def test_set_input_lists(inputs, expected, user_filesystem):
     cli_inputs = ["2.5"] + inputs
     actual_args = get_args(cli_inputs)
     actual_args = set_input_lists(actual_args)
-    assert list(actual_args.input_paths).sort() == expected_paths.sort()
+    assert set(actual_args.input_paths) == set(expected_paths)
 
 
 # This test covers non-existing single input file or directory, in this case we raise an error with message

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -6,6 +6,7 @@ import pytest
 
 from diffpy.labpdfproc.labpdfprocapp import get_args
 from diffpy.labpdfproc.tools import (
+    expand_list_file,
     known_sources,
     load_user_metadata,
     set_input_lists,
@@ -49,10 +50,6 @@ params_input = [
             "input_dir/binary.pkl",
         ],
     ),
-    (  # file_list.txt list of files provided
-        ["input_dir/file_list.txt"],
-        ["good_data.chi", "good_data.xy", "good_data.txt"],
-    ),
     (  # file_list_example2.txt list of files provided in different directories
         ["input_dir/file_list_example2.txt"],
         ["input_dir/good_data.chi", "good_data.xy", "input_dir/good_data.txt"],
@@ -68,6 +65,7 @@ def test_set_input_lists(inputs, expected, user_filesystem):
 
     cli_inputs = ["2.5"] + inputs
     actual_args = get_args(cli_inputs)
+    actual_args = expand_list_file(actual_args)
     actual_args = set_input_lists(actual_args)
     assert sorted(actual_args.input_paths) == sorted(expected_paths)
 
@@ -87,6 +85,10 @@ params_input_bad = [
         ["good_data.chi", "good_data.xy", "unreadable_file.txt", "missing_file.txt"],
         "Cannot find missing_file.txt. Please specify valid input file(s) or directories.",
     ),
+    (  # file_list.txt list of files provided (with missing files)
+        ["input_dir/file_list.txt"],
+        "Cannot find missing_file.txt. Please specify valid input file(s) or directories.",
+    ),
 ]
 
 
@@ -96,6 +98,7 @@ def test_set_input_files_bad(inputs, msg, user_filesystem):
     os.chdir(base_dir)
     cli_inputs = ["2.5"] + inputs
     actual_args = get_args(cli_inputs)
+    actual_args = expand_list_file(actual_args)
     with pytest.raises(FileNotFoundError, match=msg[0]):
         actual_args = set_input_lists(actual_args)
 

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -27,9 +27,6 @@ params_input = [
     (  # glob input directory
         ["./input_dir"],
         [
-            "./good_data.chi",
-            "./good_data.xy",
-            "./good_data.txt",
             "input_dir/good_data.chi",
             "input_dir/good_data.xy",
             "input_dir/good_data.txt",
@@ -72,7 +69,7 @@ def test_set_input_lists(inputs, expected, user_filesystem):
     cli_inputs = ["2.5"] + inputs
     actual_args = get_args(cli_inputs)
     actual_args = set_input_lists(actual_args)
-    assert set(actual_args.input_paths) == set(expected_paths)
+    assert sorted(actual_args.input_paths) == sorted(expected_paths)
 
 
 # This test covers non-existing single input file or directory, in this case we raise an error with message

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -35,17 +35,6 @@ def _parse_file_list_file(input_path):
         return input_files
 
 
-def _parse_input_paths(input_path):
-    # Takes a path to return either a list of files paths if it is a file list,
-    # a list of single file path if it is a data file, or nothing
-    if "file_list" in input_path.name:
-        return _parse_file_list_file(input_path)
-    elif input_path.is_file():
-        return [input_path]
-    else:
-        return []
-
-
 def set_input_lists(args):
     """
     Set input directory and files.
@@ -69,11 +58,16 @@ def set_input_lists(args):
         input_path = Path(input).resolve()
         if input_path.exists():
             if input_path.is_file():
-                input_paths.extend(_parse_input_paths(input_path))
+                if "file_list" in input_path.name:
+                    input_paths.extend(_parse_file_list_file(input_path))
+                else:
+                    input_paths.append(input_path)
             elif input_path.is_dir():
                 input_files = input_path.glob("*")
-                for file in input_files:
-                    input_paths.extend(_parse_input_paths(file))
+                input_files = [
+                    file.resolve() for file in input_files if file.is_file() and "file_list" not in file.name
+                ]
+                input_paths.extend(input_files)
             else:
                 raise FileNotFoundError(f"Cannot find {input}. Please specify valid input file(s) or directories.")
         else:

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -28,11 +28,20 @@ def set_output_directory(args):
     return output_dir
 
 
-def _parse_file_list_file(input_path):
-    with open(input_path, "r") as f:
-        lines = [line.strip() for line in f]
-        input_files = [Path(line).resolve() for line in lines if Path(line).is_file()]
-        return input_files
+def _parse_file_list_file(file_list_path):
+    with open(file_list_path, "r") as f:
+        # file_paths = [Path(file_path.strip()).resolve() for file_path in f.readlines()
+        # if Path(file_path.strip()).is_file()]
+        file_paths = [file_path.strip() for file_path in f.readlines()]
+        return file_paths
+
+
+def expand_list_file(input):
+    file_list_inputs = [input_name for input_name in input if "file_list" in str(input_name)]
+    for file_list_input in file_list_inputs:
+        input.remove(file_list_input)
+        input.extend(_parse_file_list_file(file_list_input))
+    return input
 
 
 def set_input_lists(args):
@@ -54,14 +63,12 @@ def set_input_lists(args):
     """
 
     input_paths = []
-    for input in args.input:
+    expanded_input = expand_list_file(args.input)
+    for input in expanded_input:
         input_path = Path(input).resolve()
         if input_path.exists():
             if input_path.is_file():
-                if "file_list" in input_path.name:
-                    input_paths.extend(_parse_file_list_file(input_path))
-                else:
-                    input_paths.append(input_path)
+                input_paths.append(input_path)
             elif input_path.is_dir():
                 input_files = input_path.glob("*")
                 input_files = [


### PR DESCRIPTION
- closes #23, #24.
- File list tests passed.
- For test case of "./input_dir", we also read the two file lists in the directory. In my current commit here I read the two file lists and append the data files in our input directories too. Please let me know if this is ideal.
- In tools.py: I added _parse_input_paths in addition to _parse_file_list_file and it returns a set of file paths for file list/single data file. list(set(input_paths)) removes the duplicates.