### PR TITLE
closes #29: initial commit on  load datetime of the analysis

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -89,6 +89,15 @@ def get_args(override_cli_inputs=None):
         "For example, facility='NSLS II', 'facility=NSLS II', beamline=28ID-2, "
         "'beamline'='28ID-2', 'favorite color'=blue, are all valid key=value items. ",
     )
+    p.add_argument(
+        "-d"
+        "--datetime_of_analysis",
+        metavar="YYYY-MM-DD HH:MI:SS",
+        help=f"The date and time of the analysis. Required."
+             "The format should be in YYYY-MM-DD HH:MM:SS format.",
+    )
+    args = p.parse_args(override_cli_inputs)
+    return args
     args = p.parse_args(override_cli_inputs)
     return args
 

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -232,3 +232,35 @@ def test_load_user_metadata_bad(inputs, msg):
     actual_args = get_args(cli_inputs)
     with pytest.raises(ValueError, match=msg[0]):
         actual_args = load_user_metadata(actual_args)
+
+
+params7 = [(["--datetime-of-analysis", "2020-02-02 00:00:00"],
+            ["--user-metadata", f"datetime={datetime.strptime("2020-02-02 00:00:00", "%Y-%m-%d %H:%M:%S")}"]),
+           (["--datetime-of-analysis", "2022-03-28 02:15:34"],
+            ["--user-metadata", f"datetime={datetime.strptime("2022-03-28 02:15:34", "%Y-%m-%d %H:%M:%S")}"]),
+           (["--datetime-of-analysis", "2022-03-30 23:15:44"],
+            ["--user-metadata", f"datetime={datetime.strptime("2022-03-28 02:15:34", "%Y-%m-%d %H:%M:%S")}"])]
+
+
+@pytest.mark.parametrize("inputs, expected", params7)
+def test_load_datetime(inputs, expected):
+    cli_inputs = ["2.5"] + inputs
+    actual_args = get_args(cli_inputs)
+    expected_datetime = expected[0]
+    actual_datetime = load_datetime(actual_args)
+    assert actual_datetime == expected_datetime
+
+
+params8 = [(["--datetime-of-analysis", "2020-13-01 02:15:34"],
+            ["Please provide a valid datetime value. For more information, use `labpdfproc --help.`"]),
+           (["--datetime-of-analysis", "nqpk-nn-01 02:15:34"],
+            ["Please provide a valid datetime value. For more information, use `labpdfproc --help.`"]),
+           (["--datetime-of-analysis", "2025-12-01 02:15:34"], ["Future date entered. Please enter a valid date."])]
+
+
+@pytest.mark.parametrize("inputs, expected", params8)
+def test_load_datetime_bad(inputs, expected):
+    cli_inputs = ["2.5", "data.xy"] + inputs
+    actual_args = get_args(cli_inputs)
+    with pytest.raises(ValueError, match=expected[0]):
+        load_datetime(actual_args)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-
+from datetime import datetime
 import pytest
 
 from diffpy.labpdfproc.labpdfprocapp import get_args
@@ -11,7 +11,7 @@ from diffpy.labpdfproc.tools import (
     load_user_metadata,
     set_input_lists,
     set_output_directory,
-    set_wavelength,
+    set_wavelength, load_datetime,
 )
 
 # Use cases can be found here: https://github.com/diffpy/diffpy.labpdfproc/issues/48

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -165,3 +165,31 @@ def load_user_metadata(args):
             setattr(args, key, value)
     delattr(args, "user_metadata")
     return args
+
+
+def load_datetime(args):
+    """
+    Load the datetime of analysis into Metadata.
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser
+
+
+    Returns
+    -------
+    the updated argparse Namespace with datetime object.
+
+    """
+    try:
+        input_date = datetime.strptime(args.datetime, '%Y-%m-%d %H:%M:%S').date()
+        current_date = datetime.now().date()
+        if input_date > current_date:
+            raise ValueError("Future date entered. Please enter a valid date.")
+        datetime_obj = datetime.strptime(args.datetime, "%Y-%m-%d %H:%M:%S")
+        user_metadata = load_user_metadata(args)
+        user_metadata.update({"datetime": datetime_obj})
+        return user_metadata
+    except ValueError:
+        raise ValueError("Please provide a valid datetime value. For more information, use `labpdfproc --help.`")

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+from datetime import datetime
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 known_sources = [key for key in WAVELENGTHS.keys()]
 


### PR DESCRIPTION
Initial commit for the load_datetime. Not sure about whether it is automatically extracted or manually created. So, in the test function, I write the version of manually written ones. If it is the former, let me change it to the correct form. Should take some return objects after executing the function. More modification needs to be done in the 2nd push of the function. 