### PR TITLE
load username and email

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
 from diffpy.labpdfproc.tools import (
     known_sources,
+    load_user_info,
     load_user_metadata,
     set_input_lists,
     set_output_directory,
@@ -96,6 +97,7 @@ def get_args(override_cli_inputs=None):
 
 def main():
     args = get_args()
+    args = load_user_info(args)
     args = set_input_lists(args)
     args.output_directory = set_output_directory(args)
     args.wavelength = set_wavelength(args)

--- a/src/diffpy/labpdfproc/tests/conftest.py
+++ b/src/diffpy/labpdfproc/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,8 @@ def user_filesystem(tmp_path):
     base_dir = Path(tmp_path)
     input_dir = base_dir / "input_dir"
     input_dir.mkdir(parents=True, exist_ok=True)
+    conf_dir = base_dir / "conf_dir"
+    conf_dir.mkdir(parents=True, exist_ok=True)
 
     chi_data = "dataformat = twotheta\n mode = xray\n # chi_Q chi_I\n 1 2\n 3 4\n 5 6\n 7 8\n"
     xy_data = "1 2\n 3 4\n 5 6\n 7 8"
@@ -43,5 +46,11 @@ def user_filesystem(tmp_path):
         f.write("input_dir/good_data.chi \n")
         f.write("good_data.xy \n")
         f.write(f"{str(input_dir.resolve() / 'good_data.txt')}\n")
+
+    user_config_data = {"username": "good_username", "email": "good@email.com"}
+    with open(conf_dir / "test.json", "w") as f:
+        json.dump(user_config_data, f)
+    with open(conf_dir / "test2.json", "w") as f:
+        json.dump({}, f)
 
     yield tmp_path

--- a/src/diffpy/labpdfproc/tests/conftest.py
+++ b/src/diffpy/labpdfproc/tests/conftest.py
@@ -48,9 +48,7 @@ def user_filesystem(tmp_path):
         f.write(f"{str(input_dir.resolve() / 'good_data.txt')}\n")
 
     user_config_data = {"username": "good_username", "email": "good@email.com"}
-    with open(conf_dir / "test.json", "w") as f:
+    with open(conf_dir / "diffpyconfig.json", "w") as f:
         json.dump(user_config_data, f)
-    with open(conf_dir / "test2.json", "w") as f:
-        json.dump({}, f)
 
     yield tmp_path

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -245,63 +245,99 @@ def test_load_user_metadata_bad(inputs, msg):
         actual_args = load_user_metadata(actual_args)
 
 
-# For each test case, check username and email are properly loaded and written into config file
 params_user_info = [
-    # No existing config file, user enters valid username and email
-    (["good_username", "good@email.com", "non_existing_file.json"], ["good_username", "good@email.com"]),
-    # There exists a config file, so we read it and fetch info, no user input is fine
-    (["", "", "test.json"], ["good_username", "good@email.com"]),
-    # There exists a config file, user input username/email overwrites the username/email in the file
-    (["new_username", "", "test.json"], ["new_username", "good@email.com"]),
-    (["", "new@email.com", "test.json"], ["good_username", "new@email.com"]),
-    (["new_username", "new@email.com", "test.json"], ["new_username", "new@email.com"]),
-    # There exists a config file that does not contain username/email, then we write user inputs into config file
-    (["good_username", "good@email.com", "test2.json"], ["good_username", "good@email.com"]),
+    # No config file, check username and email are properly loaded and config file in ~ is created and written
+    (
+        ["new_username", "new@email.com"],
+        ["input_dir", "input_dir/diffpyconfig.json", "diffpyconfig.json", "diffpyconfig.json"],
+        ["new_username", "new@email.com", "new_username", "new@email.com"],
+    ),
+    # Config file in cwd, check username and email are properly loaded and config file is unchanged
+    (
+        ["", ""],
+        ["conf_dir", "conf_dir/diffpyconfig.json", "diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["good_username", "good@email.com", "good_username", "good@email.com"],
+    ),
+    (
+        ["new_username", ""],
+        ["conf_dir", "conf_dir/diffpyconfig.json", "diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["new_username", "good@email.com", "good_username", "good@email.com"],
+    ),
+    (
+        ["", "new@email.com"],
+        ["conf_dir", "conf_dir/diffpyconfig.json", "diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["good_username", "new@email.com", "good_username", "good@email.com"],
+    ),
+    (
+        ["new_username", "new@email.com"],
+        ["conf_dir", "conf_dir/diffpyconfig.json", "diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["new_username", "new@email.com", "good_username", "good@email.com"],
+    ),
+    # Config file in home dir not in cwd, check username and email are properly loaded and config file is unchanged
+    (
+        ["", ""],
+        ["input_dir", "input_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["good_username", "good@email.com", "good_username", "good@email.com"],
+    ),
+    (
+        ["new_username", ""],
+        ["input_dir", "input_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["new_username", "good@email.com", "good_username", "good@email.com"],
+    ),
+    (
+        ["", "new@email.com"],
+        ["input_dir", "input_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["good_username", "new@email.com", "good_username", "good@email.com"],
+    ),
+    (
+        ["new_username", "new@email.com"],
+        ["input_dir", "input_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json", "conf_dir/diffpyconfig.json"],
+        ["new_username", "new@email.com", "good_username", "good@email.com"],
+    ),
 ]
 
 
-@pytest.mark.parametrize("inputs, expected", params_user_info)
-def test_load_user_info(monkeypatch, inputs, expected, user_filesystem):
-    os.chdir(user_filesystem / "conf_dir")
-    expected_username, expected_email = expected
-    input_username, input_email, input_config_file = inputs
-    mock_prompt_user_info = iter([input_username, input_email])
+@pytest.mark.parametrize("inputs, paths, expected", params_user_info)
+def test_load_user_info(monkeypatch, inputs, paths, expected, user_filesystem):
+    os.chdir(user_filesystem / paths[0])
+    expected_args_username, expected_args_email, expected_conf_username, expected_conf_email = expected
+    mock_prompt_user_info = iter(inputs)
     monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))
+    monkeypatch.setattr("diffpy.labpdfproc.user_config.CWD_CONFIG_PATH", user_filesystem / paths[1])
+    monkeypatch.setattr("diffpy.labpdfproc.user_config.HOME_CONFIG_PATH", user_filesystem / paths[2])
 
     cli_inputs = ["2.5", "data.xy"]
     actual_args = get_args(cli_inputs)
-    actual_args = load_user_info(actual_args, input_config_file)
+    actual_args = load_user_info(actual_args)
 
-    assert actual_args.username == expected_username
-    assert actual_args.email == expected_email
-    with open(input_config_file, "r") as f:
+    assert actual_args.username == expected_args_username
+    assert actual_args.email == expected_args_email
+    with open(user_filesystem / paths[3], "r") as f:
         config_data = json.load(f)
-        assert config_data == {"username": expected_username, "email": expected_email}
+        assert config_data == {"username": expected_conf_username, "email": expected_conf_email}
 
 
 params_user_info_bad = [
     # No valid username/email in config file (or no config file),
     # and user didn't enter username/email the first time they were asked
-    (["", "", "non_existing_file.json"], "Please rerun the program and provide a username and email."),
-    (["", "good@email.com", "non_existing_file.json"], "Please rerun the program and provide a username."),
-    (["good_username", "", "non_existing_file.json"], "Please rerun the program and provide an email."),
+    (["", ""], "Please rerun the program and provide a username and email."),
+    (["", "good@email.com"], "Please rerun the program and provide a username."),
+    (["good_username", ""], "Please rerun the program and provide an email."),
     # User entered an invalid email
-    (
-        ["good_username", "bad_email", "non_existing_file.json"],
-        "Please rerun the program and provide a valid email.",
-    ),
-    (["good_username", "bad_email", "test.json"], "Please rerun the program and provide a valid email."),
+    (["good_username", "bad_email"], "Please rerun the program and provide a valid email."),
 ]
 
 
 @pytest.mark.parametrize("inputs, msg", params_user_info_bad)
 def test_load_user_info_bad(monkeypatch, inputs, msg, user_filesystem):
-    os.chdir(user_filesystem / "conf_dir")
-    input_username, input_email, input_config_file = inputs
+    os.chdir(user_filesystem)
+    input_username, input_email = inputs
     mock_prompt_user_info = iter([input_username, input_email])
     monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))
+    monkeypatch.setattr("diffpy.labpdfproc.user_config.CWD_CONFIG_PATH", Path.cwd() / "diffpyconfig.json")
+    monkeypatch.setattr("diffpy.labpdfproc.user_config.HOME_CONFIG_PATH", user_filesystem / "diffpyconfig.json")
 
     cli_inputs = ["2.5", "data.xy"]
     actual_args = get_args(cli_inputs)
     with pytest.raises(ValueError, match=msg[0]):
-        actual_args = load_user_info(actual_args, config_file=input_config_file)
+        actual_args = load_user_info(actual_args)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -296,7 +296,7 @@ params_user_info_bad = [
 
 @pytest.mark.parametrize("inputs, msg", params_user_info_bad)
 def test_load_user_info_bad(monkeypatch, inputs, msg, user_filesystem):
-    os.chdir(user_filesystem)
+    os.chdir(user_filesystem / "conf_dir")
     input_username, input_email, input_config_file = inputs
     mock_prompt_user_info = iter([input_username, input_email])
     monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -246,20 +246,17 @@ def test_load_user_metadata_bad(inputs, msg):
 
 
 params_user_info_without_conf_file = [
-    (
-        ["new_username", "new@email.com"],
-        ["new_username", "new@email.com", "new_username", "new@email.com"],
-    ),
+    (["new_username", "new@email.com"], ["new_username", "new@email.com", "new_username", "new@email.com"]),
 ]
 
 
 @pytest.mark.parametrize("inputs, expected", params_user_info_without_conf_file)
 def test_load_user_info_without_conf_file(monkeypatch, inputs, expected, user_filesystem):
-    os.chdir(user_filesystem)
     expected_args_username, expected_args_email, expected_conf_username, expected_conf_email = expected
-    mock_prompt_user_info = iter(inputs)
-    monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))
-    monkeypatch.setattr("diffpy.labpdfproc.user_config.CWD_CONFIG_PATH", Path.cwd() / "diffpyconfig.json")
+
+    os.chdir(user_filesystem)
+    input_user = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _: next(input_user))
     monkeypatch.setattr("diffpy.labpdfproc.user_config.HOME_CONFIG_PATH", user_filesystem / "diffpyconfig.json")
 
     cli_inputs = ["2.5", "data.xy"]
@@ -272,36 +269,26 @@ def test_load_user_info_without_conf_file(monkeypatch, inputs, expected, user_fi
         assert config_data == {"username": expected_conf_username, "email": expected_conf_email}
 
 
-params_user_info_with_conf_file_in_cwd = [
-    (
-        ["", ""],
-        ["good_username", "good@email.com", "good_username", "good@email.com"],
-    ),
-    (
-        ["new_username", ""],
-        ["new_username", "good@email.com", "good_username", "good@email.com"],
-    ),
-    (
-        ["", "new@email.com"],
-        ["good_username", "new@email.com", "good_username", "good@email.com"],
-    ),
-    (
-        ["new_username", "new@email.com"],
-        ["new_username", "new@email.com", "good_username", "good@email.com"],
-    ),
+params_user_info_with_conf_file = [
+    (["", ""], ["good_username", "good@email.com", "good_username", "good@email.com"]),
+    (["new_username", ""], ["new_username", "good@email.com", "good_username", "good@email.com"]),
+    (["", "new@email.com"], ["good_username", "new@email.com", "good_username", "good@email.com"]),
+    (["new_username", "new@email.com"], ["new_username", "new@email.com", "good_username", "good@email.com"]),
 ]
 
 
-@pytest.mark.parametrize("inputs, expected", params_user_info_with_conf_file_in_cwd)
-def test_load_user_info_with_conf_file_cwd(monkeypatch, inputs, expected, user_filesystem):
+@pytest.mark.parametrize("inputs, expected", params_user_info_with_conf_file)
+def test_load_user_info_with_conf_file(monkeypatch, inputs, expected, user_filesystem):
+    expected_args_username, expected_args_email, expected_conf_username, expected_conf_email = expected
+    user_config_data = {"username": "good_username", "email": "good@email.com"}
+    with open(user_filesystem / "diffpyconfig.json", "w") as f:
+        json.dump(user_config_data, f)
+
     # test it works when config file is in current directory
     # check username and email are correctly loaded and config file is not modified
-    expected_args_username, expected_args_email, expected_conf_username, expected_conf_email = expected
-
     os.chdir(user_filesystem / "conf_dir")
-    mock_prompt_user_info = iter(inputs)
-    monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))
-    monkeypatch.setattr("diffpy.labpdfproc.user_config.CWD_CONFIG_PATH", Path.cwd() / "diffpyconfig.json")
+    input_user = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _: next(input_user))
     monkeypatch.setattr("diffpy.labpdfproc.user_config.HOME_CONFIG_PATH", user_filesystem / "diffpyconfig.json")
 
     cli_inputs = ["2.5", "data.xy"]
@@ -313,43 +300,13 @@ def test_load_user_info_with_conf_file_cwd(monkeypatch, inputs, expected, user_f
         config_data = json.load(f)
         assert config_data == {"username": expected_conf_username, "email": expected_conf_email}
 
-
-test_load_user_info_with_conf_file_not_cwd = [
-    (
-        ["", ""],
-        ["good_username", "good@email.com", "good_username", "good@email.com"],
-    ),
-    (
-        ["new_username", ""],
-        ["new_username", "good@email.com", "good_username", "good@email.com"],
-    ),
-    (
-        ["", "new@email.com"],
-        ["good_username", "new@email.com", "good_username", "good@email.com"],
-    ),
-    (
-        ["new_username", "new@email.com"],
-        ["new_username", "new@email.com", "good_username", "good@email.com"],
-    ),
-]
-
-
-@pytest.mark.parametrize("inputs, expected", test_load_user_info_with_conf_file_not_cwd)
-def test_load_user_info_with_conf_file_not_cwd(monkeypatch, inputs, expected, user_filesystem):
-    # test it works when config file is in home directory and not in current directory
+    # test it works when config file is in home directory and not in current directory new_dir
     # check username and email are correctly loaded and config file is not modified
-    user_config_data = {"username": "good_username", "email": "good@email.com"}
-    with open(user_filesystem / "diffpyconfig.json", "w") as f:
-        json.dump(user_config_data, f)
-    expected_args_username, expected_args_email, expected_conf_username, expected_conf_email = expected
-
     new_dir = user_filesystem / "new_dir"
     new_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(new_dir)
-    mock_prompt_user_info = iter(inputs)
-    monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))
-    monkeypatch.setattr("diffpy.labpdfproc.user_config.CWD_CONFIG_PATH", Path.cwd() / "diffpyconfig.json")
-    monkeypatch.setattr("diffpy.labpdfproc.user_config.HOME_CONFIG_PATH", user_filesystem / "diffpyconfig.json")
+    input_user = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _: next(input_user))
 
     cli_inputs = ["2.5", "data.xy"]
     actual_args = get_args(cli_inputs)
@@ -375,9 +332,8 @@ params_user_info_bad = [
 @pytest.mark.parametrize("inputs, msg", params_user_info_bad)
 def test_load_user_info_bad(monkeypatch, inputs, msg, user_filesystem):
     os.chdir(user_filesystem)
-    input_username, input_email = inputs
-    mock_prompt_user_info = iter([input_username, input_email])
-    monkeypatch.setattr("builtins.input", lambda _: next(mock_prompt_user_info))
+    input_user = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _: next(input_user))
     monkeypatch.setattr("diffpy.labpdfproc.user_config.HOME_CONFIG_PATH", user_filesystem / "diffpyconfig.json")
 
     cli_inputs = ["2.5", "data.xy"]

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from diffpy.labpdfproc.user_config import find_conf_file, read_conf_file, user_info_conf
+
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 known_sources = [key for key in WAVELENGTHS.keys()]
 
@@ -171,3 +173,17 @@ def load_user_metadata(args):
             setattr(args, key, value)
     delattr(args, "user_metadata")
     return args
+
+
+def load_user_info(args):
+    conf_file_path = find_conf_file()
+    if conf_file_path is not None:
+        conf_file = read_conf_file(conf_file_path)
+        if "username" in conf_file and "useremail" in conf_file:
+            setattr(args, "username", conf_file["username"])
+            setattr(args, "useremail", conf_file["useremail"])
+            return args
+        else:
+            return user_info_conf(args)
+    else:
+        return user_info_conf(args)

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from diffpy.labpdfproc.user_config import CONFIG_FILE, prompt_user_info, read_conf_file, write_conf_file
+from diffpy.labpdfproc.user_config import prompt_user_info, read_conf_file, write_conf_file
 
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 known_sources = [key for key in WAVELENGTHS.keys()]
@@ -175,13 +175,14 @@ def load_user_metadata(args):
     return args
 
 
-def load_user_info(args, config_file=CONFIG_FILE):
+def load_user_info(args):
     """
     Load username and email into args.
 
-    Prompt the user to enter username and email. If not provided, read from the config file.
+    Prompt the user to enter username and email.
+    If not provided, read from the config file (first from cwd, and then from home directory).
     If neither are available, raise a ValueError.
-    Save provided values to the config file (overwriting existing values if needed).
+    Save provided values to the config file if a config file doesn't exist.
 
     Parameters
     ----------
@@ -194,7 +195,7 @@ def load_user_info(args, config_file=CONFIG_FILE):
 
     """
     input_username, input_email = prompt_user_info()
-    conf_username, conf_email = read_conf_file(config_file)
+    conf_username, conf_email = read_conf_file()
 
     no_username = not input_username and not conf_username
     no_email = not input_email and not conf_email
@@ -212,5 +213,7 @@ def load_user_info(args, config_file=CONFIG_FILE):
 
     setattr(args, "username", username)
     setattr(args, "email", email)
-    write_conf_file(username, email, config_file)
+
+    if not conf_username and not conf_email:
+        write_conf_file(username, email)
     return args

--- a/src/diffpy/labpdfproc/user_config.py
+++ b/src/diffpy/labpdfproc/user_config.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-CONFIG_FILE = "labpdfprocconfig.json"
+CONFIG_FILE = "diffpyconfig.json"
 
 
 def prompt_user_info():

--- a/src/diffpy/labpdfproc/user_config.py
+++ b/src/diffpy/labpdfproc/user_config.py
@@ -1,0 +1,37 @@
+import json
+import os
+from pathlib import Path
+
+CONFIG_FILE = "labpdfprocconfig.json"
+
+
+def find_conf_file():
+    # Return config file path if such a file exists
+    if os.path.exists(CONFIG_FILE):
+        return Path(CONFIG_FILE).resolve()
+    return None
+
+
+def read_conf_file(file_path):
+    with open(file_path, "r") as f:
+        return json.load(f)
+
+
+def write_conf_file(file_path, username, useremail):
+    config = {"username": username, "useremail": useremail}
+    with open(file_path, "w") as f:
+        json.dump(config, f)
+
+
+def prompt_user_info():
+    username = input("Please enter your username (or press Enter to skip): ")
+    useremail = input("Please enter your email (or press Enter to skip): ")
+    return username, useremail
+
+
+def user_info_conf(args):
+    username, useremail = prompt_user_info()
+    write_conf_file(CONFIG_FILE, username, useremail)
+    setattr(args, "username", username)
+    setattr(args, "useremail", useremail)
+    return args

--- a/src/diffpy/labpdfproc/user_config.py
+++ b/src/diffpy/labpdfproc/user_config.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 
 CONFIG_FILE = "diffpyconfig.json"
+CWD_CONFIG_PATH = Path.cwd() / CONFIG_FILE
+HOME_CONFIG_PATH = Path.home() / CONFIG_FILE
 
 
 def prompt_user_info():
@@ -10,15 +12,23 @@ def prompt_user_info():
     return username, email
 
 
-def read_conf_file(config_file=CONFIG_FILE):
-    config_path = Path(config_file).resolve()
-    if config_path.exists() and config_path.is_file():
-        with open(config_file, "r") as f:
+def find_conf_file():
+    if CWD_CONFIG_PATH.exists() and CWD_CONFIG_PATH.is_file():
+        return CWD_CONFIG_PATH
+    elif HOME_CONFIG_PATH.exists() and HOME_CONFIG_PATH.is_file():
+        return HOME_CONFIG_PATH
+    return None
+
+
+def read_conf_file():
+    conf_file = find_conf_file()
+    if conf_file:
+        with open(conf_file, "r") as f:
             config = json.load(f)
             return config.get("username"), config.get("email")
     return None, None
 
 
-def write_conf_file(username, email, config_file=CONFIG_FILE):
-    with open(config_file, "w") as f:
+def write_conf_file(username, email):
+    with open(HOME_CONFIG_PATH, "w") as f:
         json.dump({"username": username, "email": email}, f)

--- a/src/diffpy/labpdfproc/user_config.py
+++ b/src/diffpy/labpdfproc/user_config.py
@@ -1,37 +1,24 @@
 import json
-import os
 from pathlib import Path
 
 CONFIG_FILE = "labpdfprocconfig.json"
 
 
-def find_conf_file():
-    # Return config file path if such a file exists
-    if os.path.exists(CONFIG_FILE):
-        return Path(CONFIG_FILE).resolve()
-    return None
-
-
-def read_conf_file(file_path):
-    with open(file_path, "r") as f:
-        return json.load(f)
-
-
-def write_conf_file(file_path, username, useremail):
-    config = {"username": username, "useremail": useremail}
-    with open(file_path, "w") as f:
-        json.dump(config, f)
-
-
 def prompt_user_info():
-    username = input("Please enter your username (or press Enter to skip): ")
-    useremail = input("Please enter your email (or press Enter to skip): ")
-    return username, useremail
+    username = input("Please enter your username (or press Enter to skip if you already entered before): ")
+    email = input("Please enter your email (or press Enter to skip if you already entered before): ")
+    return username, email
 
 
-def user_info_conf(args):
-    username, useremail = prompt_user_info()
-    write_conf_file(CONFIG_FILE, username, useremail)
-    setattr(args, "username", username)
-    setattr(args, "useremail", useremail)
-    return args
+def read_conf_file(config_file=CONFIG_FILE):
+    config_path = Path(config_file).resolve()
+    if config_path.exists() and config_path.is_file():
+        with open(config_file, "r") as f:
+            config = json.load(f)
+            return config.get("username"), config.get("email")
+    return None, None
+
+
+def write_conf_file(username, email, config_file=CONFIG_FILE):
+    with open(config_file, "w") as f:
+        json.dump({"username": username, "email": email}, f)


### PR DESCRIPTION
- closes #30, closes #31.
- Initial commit on UC1 and UC4 in #30. Changed the pseudocode structued in that issue to add the functionality of overwriting config file using user inputs. For tests I added two json config files in conftest.py.
- Added user_config.py to manage user configuration.
- Added load_user_info function in labpdfprocapp.py right after get_args().
- I'll address UC5 later. For the case of multiple usernames and emails, I haven't thought of a great way of doing it now..
