### PR TITLE
loading the datetime of the analysis into args

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
 from diffpy.labpdfproc.tools import (
     known_sources,
+    load_datetime,
     load_user_metadata,
     set_input_lists,
     set_output_directory,
@@ -100,6 +101,7 @@ def main():
     args.output_directory = set_output_directory(args)
     args.wavelength = set_wavelength(args)
     args = load_user_metadata(args)
+    args = load_datetime(args)
 
     for filepath in args.input_paths:
         outfilestem = filepath.stem + "_corrected"

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -1,12 +1,15 @@
 import os
 import re
+from datetime import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from diffpy.labpdfproc.labpdfprocapp import get_args
 from diffpy.labpdfproc.tools import (
     known_sources,
+    load_datetime,
     load_user_metadata,
     set_input_lists,
     set_output_directory,
@@ -241,3 +244,18 @@ def test_load_user_metadata_bad(inputs, msg):
     actual_args = get_args(cli_inputs)
     with pytest.raises(ValueError, match=msg[0]):
         actual_args = load_user_metadata(actual_args)
+
+
+params_time = [
+    (datetime(2024, 5, 20, 10, 30, 0)),
+]
+
+
+@pytest.mark.parametrize("expected", params_time)
+def test_load_datetime(expected):
+    with patch("diffpy.labpdfproc.tools.datetime") as mock_datetime:
+        mock_datetime.now.return_value = expected
+        cli_inputs = ["2.5", "data.xy"]
+        actual_args = get_args(cli_inputs)
+        actual_args = load_datetime(actual_args)
+        assert actual_args.creation_time == expected

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
@@ -170,4 +171,23 @@ def load_user_metadata(args):
                 raise ValueError(f"Please do not specify repeated keys: {key}. ")
             setattr(args, key, value)
     delattr(args, "user_metadata")
+    return args
+
+
+def load_datetime(args):
+    """
+    Create time-stamp and load it into args
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser
+
+    Returns
+    -------
+    the updated argparse Namespace with time-stamp inserted as creation_time
+
+    """
+    creation_time = datetime.now()
+    setattr(args, "creation_time", creation_time)
     return args


### PR DESCRIPTION
- Initial commit, use mocking datetime for testing.
- In labpdfprocapp.py, I loaded the time before looping and correcting each input file. Not sure if this is the best, but I think it should be loaded before we create input_pattern DO, so that later we can load it with all other metadata into the other DOs using metadata=vars(args).
- The function returns datetime to the accuracy of microseconds (i.e., an example of datetime.now() is 2024-05-20 10:50:27.76998). I only put accuracy to seconds in the test because it seems neater. Not sure what level of accuracy would we want?