### PR TITLE
implement functionality to allow input selection or skipping of files

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -30,7 +30,8 @@ def get_args(override_cli_inputs=None):
         " the list of files contained in the text-file called "
         "file_list.txt that can be found in the folder ./data), "
         "'./*.chi', 'data/*.chi' (load all files with extension .chi in the "
-        "folder ./data).",
+        "folder ./data). You can also prepend '~' to a file name to "
+        "specify files that should be excluded.",
     )
     p.add_argument(
         "-a",

--- a/src/diffpy/labpdfproc/tests/conftest.py
+++ b/src/diffpy/labpdfproc/tests/conftest.py
@@ -24,6 +24,10 @@ def user_filesystem(tmp_path):
         f.write(unreadable_data)
     with open(base_dir / "binary.pkl", "wb") as f:
         f.write(binary_data)
+    with open(base_dir / "data_corrected.chi", "w") as f:
+        pass
+    with open(base_dir / "data_cve.chi", "w") as f:
+        pass
 
     with open(input_dir / "good_data.chi", "w") as f:
         f.write(chi_data)
@@ -35,6 +39,10 @@ def user_filesystem(tmp_path):
         f.write(unreadable_data)
     with open(input_dir / "binary.pkl", "wb") as f:
         f.write(binary_data)
+    with open(input_dir / "data_corrected.chi", "w") as f:
+        pass
+    with open(input_dir / "data_cve.chi", "w") as f:
+        pass
 
     with open(input_dir / "file_list.txt", "w") as f:
         f.write("good_data.chi \n good_data.xy \n good_data.txt \n missing_file.txt")

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -65,6 +65,10 @@ params_input = [
         ["good_data*"],
         ["good_data.chi", "good_data.xy", "good_data.txt"],
     ),
+    (  # specify files do not want to read
+        [".", "~unreadable_file.txt", "~binary.pkl"],
+        ["good_data.chi", "good_data.xy", "good_data.txt"],
+    ),
 ]
 
 

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 known_sources = [key for key in WAVELENGTHS.keys()]
+EXCLUSION_KEYWORDS = ["file_list", "_corrected", "_cve"]
 
 
 def set_output_directory(args):
@@ -50,7 +51,11 @@ def _expand_user_input(args):
         args.input.remove(file_list_input)
     wildcard_inputs = [input_name for input_name in args.input if "*" in input_name]
     for wildcard_input in wildcard_inputs:
-        input_files = [str(file) for file in Path(".").glob(wildcard_input) if "file_list" not in file.name]
+        input_files = [
+            str(file)
+            for file in Path(".").glob(wildcard_input)
+            if not any(keyword in file.name for keyword in EXCLUSION_KEYWORDS)
+        ]
         args.input.extend(input_files)
         args.input.remove(wildcard_input)
     return args
@@ -84,7 +89,9 @@ def set_input_lists(args):
             elif input_path.is_dir():
                 input_files = input_path.glob("*")
                 input_files = [
-                    file.resolve() for file in input_files if file.is_file() and "file_list" not in file.name
+                    file.resolve()
+                    for file in input_files
+                    if file.is_file() and not any(keyword in file.name for keyword in EXCLUSION_KEYWORDS)
                 ]
                 input_paths.extend(input_files)
             else:

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -80,8 +80,14 @@ def set_input_lists(args):
     """
 
     input_paths = []
+    excluded_paths = []
     args = _expand_user_input(args)
     for input_name in args.input:
+        if input_name.startswith("~"):
+            input_path = Path(input_name[1:]).resolve()
+            if input_path.exists() and input_path.is_file():
+                excluded_paths.append(input_path)
+                continue
         input_path = Path(input_name).resolve()
         if input_path.exists():
             if input_path.is_file():
@@ -100,6 +106,7 @@ def set_input_lists(args):
                 )
         else:
             raise FileNotFoundError(f"Cannot find {input_name}.")
+    input_paths = [input_path for input_path in input_paths if input_path not in excluded_paths]
     setattr(args, "input_paths", list(set(input_paths)))
     return args
 


### PR DESCRIPTION
Addressing issue #52

I went through the UCs and test cases in #48 and there left these cases (I addressed UC7 and -file7,chi in this PR and will probably address UC5 in another PR):
1. UC5: multiple files, different samples (file1.chi 2.5 file2.chi 3.5)
2. UC7: automatically selects the right files to apply the correction to (don't read _corrected and _cve).
3. -file7.chi (specify files don't want to read).

For 2, I didn't add any additional test cases and put some corrected files in our tmp path.
For 3, since - would be taken as one of the arguments, I changed it to ~.