### PR TITLE
test for compute_cve()

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
           conda config --add channels conda-forge
           conda activate test
           conda install --file requirements/requirements.txt
-          conda install pytest coverage codecov
+          conda install --file requirements/requirements-dev.txt
           pip install .
 
       - name: Validate diffpy.labpdfproc

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,6 +9,7 @@ nbstripout
 pre-commit
 pre-commit-hooks
 pytest
+pytest-mock
 sphinx
 twine
 # These are dependencies of various sphinx extensions for documentation.

--- a/src/diffpy/labpdfproc/functions.py
+++ b/src/diffpy/labpdfproc/functions.py
@@ -197,7 +197,7 @@ def compute_cve(diffraction_data, mud, wavelength):
     """
 
     mu_sample_invmm = mud / 2
-    abs_correction = Gridded_circle(mu=mu_sample_invmm)
+    abs_correction = Gridded_circle(n_points_on_diameter=N_POINTS_ON_DIAMETER, mu=mu_sample_invmm)
     distances, muls = [], []
     for angle in TTH_GRID:
         abs_correction.set_distances_at_angle(angle)

--- a/src/diffpy/labpdfproc/tests/test_functions.py
+++ b/src/diffpy/labpdfproc/tests/test_functions.py
@@ -72,7 +72,7 @@ def test_compute_cve(mocker):
     expected_abdo = Diffraction_object()
     expected_abdo.insert_scattering_quantity(
         np.array([45, 60, 90]),
-        np.array([2.54253048, 2.52852515, 2.49717207]),
+        np.array([2.54253, 2.52852, 2.49717]),
         "tth",
         metadata={"thing1": 1, "thing2": "thing2"},
         name="absorption correction, cve, for test",

--- a/src/diffpy/labpdfproc/tests/test_functions.py
+++ b/src/diffpy/labpdfproc/tests/test_functions.py
@@ -56,9 +56,9 @@ def test_set_muls_at_angle(inputs, expected):
     assert actual_muls_sorted == pytest.approx(expected_muls_sorted, rel=1e-4, abs=1e-6)
 
 
-def test_compute_cve(monkeypatch):
-    monkeypatch.setattr("diffpy.labpdfproc.functions.N_POINTS_ON_DIAMETER", int(4))
-    monkeypatch.setattr("diffpy.labpdfproc.functions.TTH_GRID", np.array([45, 60, 90]))
+def test_compute_cve(mocker):
+    mocker.patch("diffpy.labpdfproc.functions.N_POINTS_ON_DIAMETER", 4)
+    mocker.patch("diffpy.labpdfproc.functions.TTH_GRID", np.array([45, 60, 90]))
     input_pattern = Diffraction_object(wavelength=1.54)
     input_pattern.insert_scattering_quantity(
         np.array([45, 60, 90]),


### PR DESCRIPTION
- closes #20
- Initial commit
- I have to add the line `n_points_on_diameter=N_POINTS_ON_DIAMETER` to make monkeypatch work in the test. It doesn't affect the current functionality but is probably not the desired behavior.. Any suggestions for this?