### PR TITLE
load args into DO metadata

### DIFF
--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -2,16 +2,7 @@ import sys
 from argparse import ArgumentParser
 
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
-from diffpy.labpdfproc.tools import (
-    known_sources,
-    load_metadata,
-    load_package_info,
-    load_user_info,
-    load_user_metadata,
-    set_input_lists,
-    set_output_directory,
-    set_wavelength,
-)
+from diffpy.labpdfproc.tools import known_sources, load_metadata, preprocessing_args
 from diffpy.utils.parsers.loaddata import loadData
 from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
@@ -113,12 +104,7 @@ def get_args(override_cli_inputs=None):
 
 def main():
     args = get_args()
-    args = load_package_info(args)
-    args = load_user_info(args)
-    args = set_input_lists(args)
-    args.output_directory = set_output_directory(args)
-    args = set_wavelength(args)
-    args = load_user_metadata(args)
+    args = preprocessing_args(args)
 
     for filepath in args.input_paths:
         outfilestem = filepath.stem + "_corrected"

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from diffpy.labpdfproc.functions import apply_corr, compute_cve
 from diffpy.labpdfproc.tools import (
     known_sources,
+    load_metadata,
     load_package_info,
     load_user_info,
     load_user_metadata,
@@ -144,7 +145,7 @@ def main():
             "tth",
             scat_quantity="x-ray",
             name=filepath.stem,
-            metadata={"muD": args.mud, "anode_type": args.anode_type},
+            metadata=load_metadata(args, filepath),
         )
 
         absorption_correction = compute_cve(input_pattern, args.mud, args.wavelength)

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -11,6 +11,7 @@ from diffpy.labpdfproc.tools import (
     load_package_info,
     load_user_info,
     load_user_metadata,
+    preprocessing_args,
     set_input_lists,
     set_output_directory,
     set_wavelength,
@@ -281,7 +282,7 @@ def test_load_package_info(mocker):
     assert actual_args.package_info == {"diffpy.labpdfproc": "1.2.3", "diffpy.utils": "3.3.0"}
 
 
-def _setup(mocker, user_filesystem):
+def test_load_metadata(mocker, user_filesystem):
     cwd = Path(user_filesystem)
     home_dir = cwd / "home_dir"
     mocker.patch("pathlib.Path.home", lambda _: home_dir)
@@ -290,20 +291,6 @@ def _setup(mocker, user_filesystem):
         "importlib.metadata.version",
         side_effect=lambda package_name: "3.3.0" if package_name == "diffpy.utils" else "1.2.3",
     )
-
-
-def _preprocess_args(args):
-    args = load_package_info(args)
-    args = load_user_info(args)
-    args = set_input_lists(args)
-    args.output_directory = set_output_directory(args)
-    args = set_wavelength(args)
-    args = load_user_metadata(args)
-    return args
-
-
-def test_load_metadata(mocker, user_filesystem):
-    _setup(mocker, user_filesystem)
     cli_inputs = [
         "2.5",
         ".",
@@ -315,7 +302,7 @@ def test_load_metadata(mocker, user_filesystem):
         "cli@email.com",
     ]
     actual_args = get_args(cli_inputs)
-    actual_args = _preprocess_args(actual_args)
+    actual_args = preprocessing_args(actual_args)
     for filepath in actual_args.input_paths:
         actual_metadata = load_metadata(actual_args, filepath)
         expected_metadata = {

--- a/src/diffpy/labpdfproc/tests/test_tools.py
+++ b/src/diffpy/labpdfproc/tests/test_tools.py
@@ -297,7 +297,7 @@ def _preprocess_args(args):
     args = load_user_info(args)
     args = set_input_lists(args)
     args.output_directory = set_output_directory(args)
-    args.wavelength = set_wavelength(args)
+    args = set_wavelength(args)
     args = load_user_metadata(args)
     return args
 
@@ -307,8 +307,6 @@ def test_load_metadata(mocker, user_filesystem):
     cli_inputs = [
         "2.5",
         ".",
-        "--wavelength",
-        "1.54",
         "--user-metadata",
         "key=value",
         "--username",
@@ -323,8 +321,8 @@ def test_load_metadata(mocker, user_filesystem):
         expected_metadata = {
             "mud": 2.5,
             "input_directory": str(filepath),
-            "anode_type": "Cu",
-            "wavelength": 1.54,
+            "anode_type": "Mo",
+            "wavelength": 0.71,
             "output_directory": str(Path.cwd().resolve()),
             "xtype": "tth",
             "key": "value",

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -218,6 +218,28 @@ def load_package_info(args):
     return args
 
 
+def preprocessing_args(args):
+    """
+    Perform preprocessing on the provided argparse Namespace
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser, default is None
+
+    Returns
+    -------
+    the updated argparse Namespace with arguments preprocessed
+    """
+    args = load_package_info(args)
+    args = load_user_info(args)
+    args = set_input_lists(args)
+    args.output_directory = set_output_directory(args)
+    args = set_wavelength(args)
+    args = load_user_metadata(args)
+    return args
+
+
 def load_metadata(args, filepath):
     """
     Load relevant metadata from args

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -111,7 +111,7 @@ def set_wavelength(args):
 
     Returns
     -------
-        float: the wavelength value
+    args argparse.Namespace
 
     we raise an ValueError if the input wavelength is non-positive
     or if the input anode_type is not one of the known sources

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -213,3 +213,36 @@ def load_package_info(args):
     metadata = get_package_info("diffpy.labpdfproc")
     setattr(args, "package_info", metadata["package_info"])
     return args
+
+
+def _set_anode_type(args):
+    if args.wavelength in WAVELENGTHS.values():
+        args.anode_type = next(key for key, value in WAVELENGTHS.items() if value == args.wavelength)
+    else:
+        delattr(args, "anode_type")
+    return args
+
+
+def load_metadata(args, filepath):
+    """
+    Load metadata from args,
+    except for anode type if wavelength does not match, and do not load output_correction or force_overwrite
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser
+
+    Returns
+    -------
+    A dictionary with all arguments from the parser
+    """
+
+    args = _set_anode_type(args)
+    metadata = vars(args)
+    exclude_keys = ["output_correction", "force_overwrite", "input", "input_paths"]
+    for key in exclude_keys:
+        metadata.pop(key, None)
+    metadata["input_directory"] = str(filepath)
+    metadata["output_directory"] = str(metadata["output_directory"])
+    return metadata

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -217,18 +217,9 @@ def load_package_info(args):
     return args
 
 
-def _set_anode_type(args):
-    if args.wavelength in WAVELENGTHS.values():
-        args.anode_type = next(key for key, value in WAVELENGTHS.items() if value == args.wavelength)
-    else:
-        delattr(args, "anode_type")
-    return args
-
-
 def load_metadata(args, filepath):
     """
-    Load metadata from args,
-    except for anode type if wavelength does not match, and do not load output_correction or force_overwrite
+    Load relevant metadata from args
 
     Parameters
     ----------
@@ -237,10 +228,9 @@ def load_metadata(args, filepath):
 
     Returns
     -------
-    A dictionary with all arguments from the parser
+    A dictionary with relevant arguments from the parser
     """
 
-    args = _set_anode_type(args)
     metadata = vars(args)
     for key in METADATA_KEYS_TO_EXCLUDE:
         metadata.pop(key, None)

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -4,6 +4,7 @@ from diffpy.utils.tools import get_package_info, get_user_info
 
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
 known_sources = [key for key in WAVELENGTHS.keys()]
+METADATA_KEYS_TO_EXCLUDE = ["output_correction", "force_overwrite", "input", "input_paths"]
 
 
 def set_output_directory(args):
@@ -240,8 +241,7 @@ def load_metadata(args, filepath):
 
     args = _set_anode_type(args)
     metadata = vars(args)
-    exclude_keys = ["output_correction", "force_overwrite", "input", "input_paths"]
-    for key in exclude_keys:
+    for key in METADATA_KEYS_TO_EXCLUDE:
         metadata.pop(key, None)
     metadata["input_directory"] = str(filepath)
     metadata["output_directory"] = str(metadata["output_directory"])

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 
 from diffpy.utils.tools import get_package_info, get_user_info
@@ -231,7 +232,7 @@ def load_metadata(args, filepath):
     A dictionary with relevant arguments from the parser
     """
 
-    metadata = vars(args)
+    metadata = copy.deepcopy(vars(args))
     for key in METADATA_KEYS_TO_EXCLUDE:
         metadata.pop(key, None)
     metadata["input_directory"] = str(filepath)


### PR DESCRIPTION
- closes #27
- initial commit
- Would it be helpful to make `_set_anode_type` (in tools.py) and `_preprocess_args` (in the test) as public functions?