### PR TITLE
add back background description and an example of instruction in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,30 @@
 .. |Tracking| image:: https://img.shields.io/badge/issue_tracking-github-blue
         :target: https://github.com/diffpy/diffpy.labpdfproc/issues
 
-Tools for processing x-ray powder diffraction data from laboratory sources
+Tools for processing x-ray powder diffraction data from laboratory sources.
 
-* LONGER DESCRIPTION HERE
+PDFgetX3 has revolutionized how PDF methods can be applied to solve nanostructure problems.
+However, the program was designed for use with Rapid Acquisition PDF (RAPDF) data from synchrotron sources.
+A key approximation inherent in the use of PDFgetX3 for RAPDF data is that absorption effects are negligible.
+This is typically not the case for laboratory x-ray diffractometers, where absorption effects can be significant.
+
+This app is designed to preprocess data from laboratory x-ray diffractometers before using PDFgetX3 to obtain PDFs.
+The app currently carries out an absorption correction assuming a parallel beam capillary geometry
+which is the most common geometry for lab PDF measurements.
+
+The theory is described in the following paper:
+
+An ad hoc Absorption Correction for Reliable
+Pair-Distribution Functions from Low Energy x-ray Sources
+Yucong Chen, Till Schertenleib, Andrew Yang, Pascal Schouwink,
+Wendy L. Queen and Simon J. L. Billinge, in preparation.
+
+The related experimental data acquisition protocols are described in the following paper:
+
+Protocols for Obtaining Reliable PDFs from Laboratory
+x-ray Sources Using PDFgetX3,
+Till Schertenleib, Daniel Schmuckler, Yucong Chen, Geng Bang Jin,
+Wendy L. Queen and Simon J. L. Billinge, in preparation.
 
 For more information about the diffpy.labpdfproc library, please consult our `online documentation <https://diffpy.github.io/diffpy.labpdfproc>`_.
 
@@ -85,6 +106,27 @@ and run the following ::
 
         pip install .
 
+Example
+-------
+
+Navigate to the directory that contains 1D diffraction patterns that you would like to process.
+Activate the conda environment (`conda activate diffpy.labpdfproc_env`) that contains the package and run the following command ::
+
+        labpdfproc <muD> <path/to/inputfile.txt>
+
+Here replace <muD> with the value of muD for your sample
+and <path/to/inputfile.txt> with the path and filename of your input file.
+For example, if the uncorrected data case is called zro2_mo.xy and is in the current directory
+and it has a muD of 2.5 then the command would be ::
+
+        labpdfproc 2.5 zro2_mo.xy
+
+Please type ::
+
+        labpdfproc --help
+
+for more information on the available options.
+
 Support and Contribute
 ----------------------
 
@@ -113,7 +155,7 @@ trying to commit again.
 
 Improvements and fixes are always appreciated.
 
-Before contribuing, please read our `Code of Conduct <https://github.com/diffpy/diffpy.labpdfproc/blob/main/CODE_OF_CONDUCT.rst>`_.
+Before contributing, please read our `Code of Conduct <https://github.com/diffpy/diffpy.labpdfproc/blob/main/CODE_OF_CONDUCT.rst>`_.
 
 Contact
 -------


### PR DESCRIPTION
I'm adding back the background description and an example of running the app from the previous README.rst. They can be found in #84.