### PR TITLE
Implement xtype other than tth

### DIFF
--- a/news/xtype.rst
+++ b/news/xtype.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for independent variables other than two-theta.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/labpdfproc/functions.py
+++ b/src/diffpy/labpdfproc/functions.py
@@ -264,9 +264,9 @@ def compute_cve(diffraction_data, mud, method="polynomial_interpolation"):
     """
 
     cve_function = _cve_method(method)
-    abdo_on_global_tth = cve_function(diffraction_data, mud)
-    global_tth = abdo_on_global_tth.on_tth[0]
-    cve_on_global_tth = abdo_on_global_tth.on_tth[1]
+    cve_do_on_global_tth = cve_function(diffraction_data, mud)
+    global_tth = cve_do_on_global_tth.on_tth[0]
+    cve_on_global_tth = cve_do_on_global_tth.on_tth[1]
     orig_grid = diffraction_data.on_tth[0]
     newcve = np.interp(orig_grid, global_tth, cve_on_global_tth)
     cve_do = Diffraction_object(wavelength=diffraction_data.wavelength)

--- a/src/diffpy/labpdfproc/functions.py
+++ b/src/diffpy/labpdfproc/functions.py
@@ -244,39 +244,6 @@ def _cve_method(method):
     return methods[method]
 
 
-def interpolate_to_xtype_grid(cve_do, xtype):
-    f"""
-    interpolates the cve grid to the xtype user specified
-
-    Parameters
-    ----------
-    cve_do Diffraction_object
-      the diffraction object that contains the cve to be applied
-    xtype str
-      the quantity on the independent variable axis, allowed values are {*XQUANTITIES, }
-
-    Returns
-    -------
-    the new diffraction object with interpolated cve curves
-    """
-    if xtype == "tth":
-        return cve_do
-
-    orig_grid, orig_cve = cve_do.on_tth[0], cve_do.on_tth[1]
-    new_grid = cve_do.tth_to_q()
-    new_cve = np.interp(new_grid, orig_grid, orig_cve)
-    new_cve_do = Diffraction_object(wavelength=cve_do.wavelength)
-    new_cve_do.insert_scattering_quantity(
-        new_grid,
-        new_cve,
-        xtype,
-        metadata=cve_do.metadata,
-        name=cve_do.name,
-        scat_quantity="cve",
-    )
-    return new_cve_do
-
-
 def compute_cve(diffraction_data, mud, method="polynomial_interpolation", xtype="tth"):
     f"""
     compute and interpolate the cve for the given diffraction data and mud using the selected method
@@ -298,11 +265,10 @@ def compute_cve(diffraction_data, mud, method="polynomial_interpolation", xtype=
     """
 
     cve_function = _cve_method(method)
-    cve_do_on_global_tth = cve_function(diffraction_data, mud)
-    cve_do_on_global_xtype = interpolate_to_xtype_grid(cve_do_on_global_tth, xtype)
+    cve_do_on_global_grid = cve_function(diffraction_data, mud)
     orig_grid = diffraction_data.on_xtype(xtype)[0]
-    global_xtype = cve_do_on_global_xtype.on_xtype(xtype)[0]
-    cve_on_global_xtype = cve_do_on_global_xtype.on_xtype(xtype)[1]
+    global_xtype = cve_do_on_global_grid.on_xtype(xtype)[0]
+    cve_on_global_xtype = cve_do_on_global_grid.on_xtype(xtype)[1]
     newcve = np.interp(orig_grid, global_xtype, cve_on_global_xtype)
     cve_do = Diffraction_object(wavelength=diffraction_data.wavelength)
     cve_do.insert_scattering_quantity(

--- a/src/diffpy/labpdfproc/functions.py
+++ b/src/diffpy/labpdfproc/functions.py
@@ -5,12 +5,7 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
 
-from diffpy.utils.scattering_objects.diffraction_objects import (
-    ANGLEQUANTITIES,
-    DQUANTITIES,
-    XQUANTITIES,
-    Diffraction_object,
-)
+from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
 
 RADIUS_MM = 1
 N_POINTS_ON_DIAMETER = 300
@@ -251,7 +246,7 @@ def _cve_method(method):
 
 def interpolate_to_xtype_grid(cve_do, xtype):
     f"""
-    interpolates the cve grid to the xtype user specifies, raise an error if xtype is invalid
+    interpolates the cve grid to the xtype user specified
 
     Parameters
     ----------
@@ -264,10 +259,7 @@ def interpolate_to_xtype_grid(cve_do, xtype):
     -------
     the new diffraction object with interpolated cve curves
     """
-
-    if xtype.lower() not in XQUANTITIES:
-        raise ValueError(f"Unknown xtype: {xtype}. Allowed xtypes are {*XQUANTITIES, }.")
-    if xtype.lower() in ANGLEQUANTITIES or xtype.lower() in DQUANTITIES:
+    if xtype == "tth":
         return cve_do
 
     orig_grid, orig_cve = cve_do.on_tth[0], cve_do.on_tth[1]

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -63,8 +63,7 @@ def get_args(override_cli_inputs=None):
         help=(
             f"The quantity on the independent variable axis. Allowed "
             f"values: {*XQUANTITIES, }. If not specified then two-theta "
-            f"is assumed for the independent variable. Only implemented for "
-            f"tth currently."
+            f"is assumed for the independent variable."
         ),
         default="tth",
     )
@@ -160,19 +159,19 @@ def main():
         input_pattern.insert_scattering_quantity(
             xarray,
             yarray,
-            "tth",
+            args.xtype,
             scat_quantity="x-ray",
             name=filepath.stem,
             metadata=load_metadata(args, filepath),
         )
 
-        absorption_correction = compute_cve(input_pattern, args.mud, args.method)
+        absorption_correction = compute_cve(input_pattern, args.mud, args.method, args.xtype)
         corrected_data = apply_corr(input_pattern, absorption_correction)
         corrected_data.name = f"Absorption corrected input_data: {input_pattern.name}"
-        corrected_data.dump(f"{outfile}", xtype="tth")
+        corrected_data.dump(f"{outfile}", xtype=args.xtype)
 
         if args.output_correction:
-            absorption_correction.dump(f"{corrfile}", xtype="tth")
+            absorption_correction.dump(f"{corrfile}", xtype=args.xtype)
 
 
 if __name__ == "__main__":

--- a/src/diffpy/labpdfproc/tools.py
+++ b/src/diffpy/labpdfproc/tools.py
@@ -2,6 +2,7 @@ import copy
 from pathlib import Path
 
 from diffpy.labpdfproc.mud_calculator import compute_mud
+from diffpy.utils.scattering_objects.diffraction_objects import QQUANTITIES, XQUANTITIES
 from diffpy.utils.tools import get_package_info, get_user_info
 
 WAVELENGTHS = {"Mo": 0.71, "Ag": 0.59, "Cu": 1.54}
@@ -135,6 +136,25 @@ def set_wavelength(args):
     return args
 
 
+def set_xtype(args):
+    f"""
+    Set the xtype based on the given input arguments, raise an error if xtype is not one of {*XQUANTITIES, }
+
+    Parameters
+    ----------
+    args argparse.Namespace
+        the arguments from the parser
+
+    Returns
+    -------
+    args argparse.Namespace
+    """
+    if args.xtype.lower() not in XQUANTITIES:
+        raise ValueError(f"Unknown xtype: {args.xtype}. Allowed xtypes are {*XQUANTITIES, }.")
+    args.xtype = "q" if args.xtype.lower() in QQUANTITIES else "tth"
+    return args
+
+
 def set_mud(args):
     """
     Set the mud based on the given input arguments
@@ -257,6 +277,7 @@ def preprocessing_args(args):
     args = set_input_lists(args)
     args.output_directory = set_output_directory(args)
     args = set_wavelength(args)
+    args = set_xtype(args)
     args = set_mud(args)
     args = load_user_metadata(args)
     return args

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -10,7 +10,7 @@ from diffpy.labpdfproc.functions import (
     compute_cve,
     interpolate_to_xtype_grid,
 )
-from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Diffraction_object
+from diffpy.utils.scattering_objects.diffraction_objects import Diffraction_object
 
 params1 = [
     ([0.5, 3, 1], {(0.0, -0.5), (0.0, 0.0), (0.5, 0.0), (-0.5, 0.0), (0.0, 0.5)}),
@@ -104,20 +104,6 @@ def test_interpolate_xtype(inputs, expected, mocker):
     )
     actual_cve_do = interpolate_to_xtype_grid(input_cve_do, xtype=inputs[2])
     assert actual_cve_do == expected_cve_do
-
-
-def test_interpolate_xtype_bad():
-    input_cve_do = _instantiate_test_do(
-        np.array([30, 60, 90]),
-        np.array([1, 2, 3]),
-        xtype="tth",
-        name="absorption correction, cve, for test",
-        scat_quantity="cve",
-    )
-    with pytest.raises(
-        ValueError, match=re.escape(f"Unknown xtype: invalid. Allowed xtypes are {*XQUANTITIES, }.")
-    ):
-        interpolate_to_xtype_grid(input_cve_do, xtype="invalid")
 
 
 def test_compute_cve(mocker):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,13 +3,7 @@ import re
 import numpy as np
 import pytest
 
-from diffpy.labpdfproc.functions import (
-    CVE_METHODS,
-    Gridded_circle,
-    apply_corr,
-    compute_cve,
-    interpolate_to_xtype_grid,
-)
+from diffpy.labpdfproc.functions import CVE_METHODS, Gridded_circle, apply_corr, compute_cve
 from diffpy.utils.scattering_objects.diffraction_objects import Diffraction_object
 
 params1 = [
@@ -78,44 +72,23 @@ def _instantiate_test_do(xarray, yarray, xtype="tth", name="test", scat_quantity
 
 
 params4 = [
-    ([np.array([30, 60, 90]), np.array([1, 2, 3]), "tth"], [np.array([30, 60, 90]), np.array([1, 2, 3]), "tth"]),
-    (
-        [np.array([30, 60, 90]), np.array([1, 2, 3]), "q"],
-        [np.array([2.11195, 4.07999, 5.76998]), np.array([1, 1, 1]), "q"],
-    ),
+    (["tth"], [np.array([90, 90.1, 90.2]), np.array([0.5, 0.5, 0.5]), "tth"]),
+    (["q"], [np.array([5.76998, 5.77501, 5.78004]), np.array([0.5, 0.5, 0.5]), "q"]),
 ]
 
 
 @pytest.mark.parametrize("inputs, expected", params4)
-def test_interpolate_xtype(inputs, expected, mocker):
-    expected_cve_do = _instantiate_test_do(
-        expected[0],
-        expected[1],
-        xtype=expected[2],
-        name="absorption correction, cve, for test",
-        scat_quantity="cve",
-    )
-    input_cve_do = _instantiate_test_do(
-        inputs[0],
-        inputs[1],
-        xtype="tth",
-        name="absorption correction, cve, for test",
-        scat_quantity="cve",
-    )
-    actual_cve_do = interpolate_to_xtype_grid(input_cve_do, xtype=inputs[2])
-    assert actual_cve_do == expected_cve_do
-
-
-def test_compute_cve(mocker):
+def test_compute_cve(inputs, expected, mocker):
     xarray, yarray = np.array([90, 90.1, 90.2]), np.array([2, 2, 2])
     expected_cve = np.array([0.5, 0.5, 0.5])
     mocker.patch("diffpy.labpdfproc.functions.TTH_GRID", xarray)
     mocker.patch("numpy.interp", return_value=expected_cve)
     input_pattern = _instantiate_test_do(xarray, yarray)
-    actual_cve_do = compute_cve(input_pattern, mud=1)
+    actual_cve_do = compute_cve(input_pattern, mud=1, method="polynomial_interpolation", xtype=inputs[0])
     expected_cve_do = _instantiate_test_do(
-        xarray,
-        expected_cve,
+        expected[0],
+        expected[1],
+        expected[2],
         name="absorption correction, cve, for test",
         scat_quantity="cve",
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,7 +16,9 @@ from diffpy.labpdfproc.tools import (
     set_mud,
     set_output_directory,
     set_wavelength,
+    set_xtype,
 )
+from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES
 
 # Use cases can be found here: https://github.com/diffpy/diffpy.labpdfproc/issues/48
 
@@ -187,6 +189,31 @@ def test_set_wavelength_bad(inputs, msg):
     actual_args = get_args(cli_inputs)
     with pytest.raises(ValueError, match=re.escape(msg[0])):
         actual_args = set_wavelength(actual_args)
+
+
+params4 = [
+    ([], ["tth"]),
+    (["--xtype", "2theta"], ["tth"]),
+    (["--xtype", "d"], ["tth"]),
+    (["--xtype", "q"], ["q"]),
+]
+
+
+@pytest.mark.parametrize("inputs, expected", params4)
+def test_set_xtype(inputs, expected):
+    cli_inputs = ["2.5", "data.xy"] + inputs
+    actual_args = get_args(cli_inputs)
+    actual_args = set_xtype(actual_args)
+    assert actual_args.xtype == expected[0]
+
+
+def test_set_xtype_bad():
+    cli_inputs = ["2.5", "data.xy", "--xtype", "invalid"]
+    actual_args = get_args(cli_inputs)
+    with pytest.raises(
+        ValueError, match=re.escape(f"Unknown xtype: invalid. Allowed xtypes are {*XQUANTITIES, }.")
+    ):
+        actual_args = set_xtype(actual_args)
 
 
 def test_set_mud(user_filesystem):


### PR DESCRIPTION
closes #45 

I implemented functions to allow corrections on grid other than tth. The edits include:
- In the main module, replace all "tth" with args.xtype.
- In the tools module, filter out invalid xtype or set args.xtype to "tth" or "q" based on inputs (this makes it easy to write the output files using the dump function).
- In compute_cve function in functions.py, interpolate cve_do we get from the global tth to the input grid.

Question: I didn't see functions that allow transfer between tth and d, so when xtype=d do we simply put xtype=tth?
@sbillinge ready for some feedback.