### PR TITLE
add xraydb function to compute muD

### DIFF
--- a/news/muD.rst
+++ b/news/muD.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* function to compute mu*D based on basic information provided
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -129,6 +129,7 @@ def get_args(override_cli_inputs=None):
         help="Path to the z-scan file to be loaded to determine the mu*D value.",
         default=None,
     )
+    p.add_argument("--mu", help="The sample linear absorption coefficient.", default=None, type=float)
     p.add_argument("--sample", help="The chemical formula or name of your material.", default=None)
     p.add_argument("--energy", help="The energy in eV", default=None, type=float)
     p.add_argument("--density", help="The material density in gr/cm^3.", default=None, type=float)

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -9,7 +9,7 @@ from diffpy.utils.scattering_objects.diffraction_objects import XQUANTITIES, Dif
 
 def get_args(override_cli_inputs=None):
     p = ArgumentParser()
-    p.add_argument("mud", help="Value of mu*D for your " "sample. Required.", type=float)
+    p.add_argument("mud", nargs="?", help="Value of mu*D for your sample.", default=None, type=float)
     p.add_argument(
         "input",
         nargs="+",
@@ -126,9 +126,13 @@ def get_args(override_cli_inputs=None):
     p.add_argument(
         "-z",
         "--z-scan-file",
-        help="Path to the z-scan file to be loaded to determine the mu*D value",
+        help="Path to the z-scan file to be loaded to determine the mu*D value.",
         default=None,
     )
+    p.add_argument("--sample", help="The chemical formula or name of your material.", default=None)
+    p.add_argument("--energy", help="The energy in eV", default=None, type=float)
+    p.add_argument("--density", help="The material density in gr/cm^3.", default=None, type=float)
+    p.add_argument("--diameter", help="The capillary diameter in mm.", default=None, type=float)
     args = p.parse_args(override_cli_inputs)
     return args
 


### PR DESCRIPTION
closes #9

I have added optional arguments (mu, d, sample, energy, density) that can be used with the xraydb function to compute muD. I didn't put any error messages for invalid inputs, because I think both the input function and xraydb give clear enough error messages (e.g. for invalid float number or incorrect sample names), but I can add some if needed.

@sbillinge ready for review