### PR TITLE
Use `pip install` in GitHub CI to support `Gooey` for Python 3.13 conda env

### DIFF
--- a/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
@@ -11,11 +11,51 @@ on:
   workflow_dispatch:
 
 jobs:
-  matrix-coverage:
-    uses: Billingegroup/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@v0
-    with:
-      project: diffpy.labpdfproc
-      c_extension: false
-      headless: false
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  coverage:
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        python-version: ["3.11", "3.12", "3.13"]
+    env:
+          LATEST_PYTHON_VERSION: "3.13"
+    steps:
+      - name: Check out diffpy.labpdfproc
+        uses: actions/checkout@v4
+
+      - name: Initialize miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          auto-update-conda: true
+          environment-file: environment.yml
+          auto-activate-base: false
+          python-version: ${{ matrix.python-version }}
+
+      - name: Conda config
+        run: >-
+          conda config --set always_yes yes
+          --set changeps1 no
+
+      - name: Install diffpy.labpdfproc and requirements
+        run: |
+          conda install --file requirements/test.txt
+          pip install -r requirements/pip.txt
+          python -m pip install . --no-deps
+
+      - name: Validate diffpy.labpdfproc
+        run: |
+          pytest --cov
+          coverage report -m
+          codecov
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == env.LATEST_PYTHON_VERSION
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: secrets.CODECOV_TOKEN

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -8,11 +8,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests-on-pr:
-    uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@v0
-    with:
-      project: diffpy.labpdfproc
-      c_extension: false
-      headless: false
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  validate:
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out diffpy.labpdfproc repository
+        uses: actions/checkout@v4
+
+      - name: Initialize miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          auto-update-conda: true
+          environment-file: environment.yml
+          auto-activate-base: false
+          python-version: 3.13
+
+      - name: Conda config
+        run: >-
+          conda config --set always_yes yes
+          --set changeps1 no
+
+      - name: Install diffpy.labpdfproc and requirements
+        run: |
+          conda install --file requirements/test.txt
+          pip install -r requirements/pip.txt
+          python -m pip install . --no-deps
+
+    
+      - name: Validate diffpy.labpdfproc
+        run: |
+          pytest --cov
+          coverage report -m
+          codecov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true
+          fail_ci_if_error: true
+          token: secrets.CODECOV_TOKEN


### PR DESCRIPTION
The current PR https://github.com/diffpy/diffpy.labpdfproc/pull/130 fails since it attempts to `conda install` the Gooey package. However, Gooey's latest conda package support up to py3.10 while our CI setups a py3.13 env.

### Constraint
- We do not want to downgrade `labpdfproc` Python support

### Solution
- Download Gooey via pip package (pure Python) which supports Py3.13

### Impact
- This means that for `labpdfproc`, we might have to change the README instructions on how to install labpdfproc.

After this PR is merged  I will create an GH issue here to ensure we use the reusable CI workflows once Gooey supports 3.13
