### PR TITLE
fix: corrected mu vs muD usage, remove packing fraction option

### DIFF
--- a/news/remove-pf.rst
+++ b/news/remove-pf.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news added - corrected mu vs muD usage and removed packing fraction option for estimating muD
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/labpdfproc/labpdfprocapp.py
+++ b/src/diffpy/labpdfproc/labpdfprocapp.py
@@ -12,13 +12,6 @@ from diffpy.labpdfproc.tools import (
 from diffpy.utils.diffraction_objects import XQUANTITIES, DiffractionObject
 from diffpy.utils.parsers.loaddata import loadData
 
-theoretical_mud_hmsg_suffix = (
-    "in that exact order, "
-    "separated by commas (e.g., ZrO2,17.45,0.5). "
-    "If you add whitespaces, "
-    "enclose it in quotes (e.g., 'ZrO2, 17.45, 0.5'). "
-)
-
 
 def _define_arguments():
     args = [
@@ -163,46 +156,39 @@ def _add_mud_selection_group(p, use_gui=False):
     """Current Options:
     1. Manually enter muD (`--mud`).
     2. Estimate from a z-scan file (`-z` or `--z-scan-file`).
-    3. Estimate theoretically based on sample mass density
-    (`-d` or `--theoretical-from-density`).
-    4. Estimate theoretically based on packing fraction
-    (`-p` or `--theoretical-from-packing`).
+    3. Estimate theoretically based on relevant chemical information
+    (`-t` or `--theoretical-estimation`).
     """
-    g = p.add_argument_group("Options for setting mu*D value (Required)")
+    g = p.add_argument_group("Options for setting muD value (Required)")
     g = g.add_mutually_exclusive_group(required=True)
     g.add_argument(
         "--mud",
         type=float,
-        help="Enter the mu*D value manually.",
+        help="Enter the muD value manually.",
         **({"widget": "DecimalField"} if use_gui else {}),
     )
     g.add_argument(
         "-z",
         "--z-scan-file",
         help=(
-            "Estimate mu*D experimentally from a z-scan file. "
+            "Estimate muD experimentally from a z-scan file. "
             "Specify the path to the file "
-            "used to compute the mu*D value."
+            "used to compute the muD value."
         ),
         **({"widget": "FileChooser"} if use_gui else {}),
     )
     g.add_argument(
-        "-d",
-        "--theoretical-from-density",
+        "-t",
+        "--theoretical-estimation",
         help=(
-            "Estimate mu*D theoretically using sample mass density. "
+            "Estimate muD theoretically. "
             "Specify the chemical formula, incident x-ray energy (in keV), "
-            "and sample mass density (in g/cm^3), "
-            + theoretical_mud_hmsg_suffix
-        ),
-    )
-    g.add_argument(
-        "-p",
-        "--theoretical-from-packing",
-        help=(
-            "Estimate mu*D theoretically using packing fraction. "
-            "Specify the chemical formula, incident x-ray energy (in keV), "
-            "and packing fraction (0 to 1), " + theoretical_mud_hmsg_suffix
+            "sample mass density (in g/cm^3), "
+            "and capillary diameter (in mm) "
+            "in that exact order, "
+            "separated by commas (e.g., ZrO2,17.45,0.5,1.0). "
+            "If you add whitespaces, "
+            "enclose it in quotes (e.g., 'ZrO2, 17.45, 0.5, 1.0'). "
         ),
     )
     return p

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -462,14 +462,10 @@ def test_set_xtype_bad():
         # C2: user provides a z-scan file, expect to estimate through the file
         (["--z-scan-file", "test_dir/testfile.xy"], 3),
         # C3: user specifies sample composition, energy,
-        # and sample mass density,
+        # sample mass density, and capillary diameter,
         # both with and without whitespaces, expect to estimate theoretically
-        (["--theoretical-from-density", "ZrO2,17.45,1.2"], 1.49),
-        (["--theoretical-from-density", "ZrO2, 17.45, 1.2"], 1.49),
-        # C4: user specifies sample composition, energy, and packing fraction
-        # both with and without whitespaces, expect to estimate theoretically
-        # (["--theoretical-from-packing", "ZrO2,17.45,0.3"], 1.49),
-        # (["--theoretical-from-packing", "ZrO2, 17.45, 0.3"], 1.49),
+        (["--theoretical-estimation", "ZrO2,17.45,1.2,1.0"], 1.49),
+        (["--theoretical-estimation", "ZrO2, 17.45, 1.2,1.0"], 1.49),
     ],
 )
 def test_set_mud(user_filesystem, inputs, expected_mud):
@@ -493,56 +489,28 @@ def test_set_mud(user_filesystem, inputs, expected_mud):
                 "Cannot find invalid file. Please specify a valid file path.",
             ],
         ),
-        # C2.1: (sample mass density option)
-        # user provides fewer than three input values
+        # C2: user provides fewer than 4 inputs for theoretical estimation,
         # expect ValueError with a message indicating the correct format
         (
-            ["--theoretical-from-density", "ZrO2,0.5"],
+            ["--theoretical-estimation", "ZrO2,0.5"],
             [
                 ValueError,
-                "Invalid mu*D input 'ZrO2,0.5'. "
+                "Invalid muD input 'ZrO2,0.5'. "
                 "Expected format is 'sample composition, energy, "
-                "sample mass density or packing fraction' "
-                "(e.g., 'ZrO2,17.45,0.5').",
+                "sample mass density, capillary diameter' "
+                "(e.g., 'ZrO2,17.45,0.5,1.0').",
             ],
         ),
-        # C2.2: (packing fraction option)
-        # user provides fewer than three input values
+        # C3: user provides more than 4 inputs for theoretical estimation
         # expect ValueError with a message indicating the correct format
         (
-            ["--theoretical-from-packing", "ZrO2,0.5"],
+            ["--theoretical-estimation", "ZrO2,17.45,1.5,0.5,1.0"],
             [
                 ValueError,
-                "Invalid mu*D input 'ZrO2,0.5'. "
+                "Invalid muD input 'ZrO2,17.45,1.5,0.5,1.0'. "
                 "Expected format is 'sample composition, energy, "
-                "sample mass density or packing fraction' "
-                "(e.g., 'ZrO2,17.45,0.5').",
-            ],
-        ),
-        # C3.1: (sample mass density option)
-        # user provides more than 3 input values
-        # expect ValueError with a message indicating the correct format
-        (
-            ["--theoretical-from-density", "ZrO2,17.45,1.5,0.5"],
-            [
-                ValueError,
-                "Invalid mu*D input 'ZrO2,17.45,1.5,0.5'. "
-                "Expected format is 'sample composition, energy, "
-                "sample mass density or packing fraction' "
-                "(e.g., 'ZrO2,17.45,0.5').",
-            ],
-        ),
-        # C3.2: (packing fraction option)
-        # user provides more than 3 input values
-        # expect ValueError with a message indicating the correct format
-        (
-            ["--theoretical-from-packing", "ZrO2,17.45,1.5,0.5"],
-            [
-                ValueError,
-                "Invalid mu*D input 'ZrO2,17.45,1.5,0.5'. "
-                "Expected format is 'sample composition, energy, "
-                "sample mass density or packing fraction' "
-                "(e.g., 'ZrO2,17.45,0.5').",
+                "sample mass density, capillary diameter' "
+                "(e.g., 'ZrO2,17.45,0.5,1.0').",
             ],
         ),
     ],


### PR DESCRIPTION
closes #188, closes #187
- Removed packing fraction option for theoretical muD estimation
- Fixed issues where mu was incorrectly treated as muD
Docs update for this PR is tracked through #192.

Here's a screenshot of the GUI:
![1](https://github.com/user-attachments/assets/c5e8b9ec-153f-4284-9eb0-715ae57572f7)

@sbillinge ready for review.