### PR TITLE
build: Add support for python 3.14 and remove support for python 3.11

### DIFF
--- a/news/py314.rst
+++ b/news/py314.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for Python 3.14
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Support for Python 3.11
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "Tools for processing x-ray powder diffraction data from laboratory sources."
 keywords = ['powder xrd', 'absorption correction', 'pdf', 'diffpy']
 readme = "README.rst"
-requires-python = ">=3.11, <3.14"
+requires-python = ">=3.12, <3.15"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -25,9 +25,9 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]


### PR DESCRIPTION
@sbillinge Ready to review, Closes #203 
P.S After the workflow run, I realized that `diffpy.labpdfproc` still uses the old version of workflow for `test-on-pr`, that is why the python version is hard-coded in the workflow and did not run the latest version of python.